### PR TITLE
리뷰 CRUD 구현

### DIFF
--- a/src/main/java/com/team19/musuimsa/config/JpaAuditingConfig.java
+++ b/src/main/java/com/team19/musuimsa/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.team19.musuimsa.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/team19/musuimsa/dateTime/BaseEntity.java
+++ b/src/main/java/com/team19/musuimsa/dateTime/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.team19.musuimsa.dateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}
+

--- a/src/main/java/com/team19/musuimsa/exception/notfound/ReviewNotFoundException.java
+++ b/src/main/java/com/team19/musuimsa/exception/notfound/ReviewNotFoundException.java
@@ -1,0 +1,8 @@
+package com.team19.musuimsa.exception.notfound;
+
+public class ReviewNotFoundException extends EntityNotFoundException {
+
+    public ReviewNotFoundException(Long reviewId) {
+        super("해당 ID의 리뷰를 찾을 수 없습니다: " + reviewId);
+    }
+}

--- a/src/main/java/com/team19/musuimsa/exception/notfound/ShelterNotFoundException.java
+++ b/src/main/java/com/team19/musuimsa/exception/notfound/ShelterNotFoundException.java
@@ -1,0 +1,8 @@
+package com.team19.musuimsa.exception.notfound;
+
+public class ShelterNotFoundException extends EntityNotFoundException {
+
+    public ShelterNotFoundException(Long shelterId) {
+        super("해당 ID의 쉼터를 찾을 수 없습니다: " + shelterId);
+    }
+}

--- a/src/main/java/com/team19/musuimsa/review/controller/ReviewController.java
+++ b/src/main/java/com/team19/musuimsa/review/controller/ReviewController.java
@@ -1,0 +1,87 @@
+package com.team19.musuimsa.review.controller;
+
+import com.team19.musuimsa.review.dto.CreateReviewRequest;
+import com.team19.musuimsa.review.dto.CreateReviewResponse;
+import com.team19.musuimsa.review.dto.ReviewDto;
+import com.team19.musuimsa.review.dto.UpdateReviewRequest;
+import com.team19.musuimsa.review.service.ReviewService;
+import com.team19.musuimsa.user.domain.User;
+import java.nio.file.AccessDeniedException;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    public ReviewController(ReviewService reviewService) {
+        this.reviewService = reviewService;
+    }
+
+    // 리뷰 생성
+    @PostMapping("/shelters/{shelterId}/reviews")
+    public ResponseEntity<CreateReviewResponse> createReview(
+            @RequestBody CreateReviewRequest request, @PathVariable Long shelterId, @AuthenticationPrincipal User user) {
+
+        CreateReviewResponse response = reviewService.createReview(shelterId, request, user);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(response);
+    }
+
+    // 리뷰 수정
+    @PatchMapping("/reviews/{reviewId}")
+    public ResponseEntity<ReviewDto> updateReview(@PathVariable Long reviewId,
+            @RequestBody UpdateReviewRequest request, @AuthenticationPrincipal User user)
+            throws AccessDeniedException {
+
+        ReviewDto response = reviewService.updateReview(reviewId, request, user);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(response);
+    }
+
+    // 리뷰 삭제
+    @DeleteMapping("/reviews/{reviewId}")
+    public ResponseEntity<Void> deleteReview(@PathVariable Long reviewId,
+            @AuthenticationPrincipal User user)
+            throws AccessDeniedException {
+
+        reviewService.deleteReview(reviewId, user);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    // 쉼터 리뷰 조회
+    @GetMapping("/shelters/{shelterId}/reviews")
+    public ResponseEntity<List<ReviewDto>> getReviewByShelter(@PathVariable Long shelterId) {
+
+        List<ReviewDto> reviews = reviewService.getReviewsByShelter(shelterId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(reviews);
+    }
+
+    // 내가 쓴 리뷰 조회
+    @GetMapping("/users/me/reviews")
+    public ResponseEntity<List<ReviewDto>> getReviewByUser(@AuthenticationPrincipal User user) {
+
+        List<ReviewDto> reviews = reviewService.getReviewsByUser(user);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(reviews);
+    }
+}

--- a/src/main/java/com/team19/musuimsa/review/domain/Review.java
+++ b/src/main/java/com/team19/musuimsa/review/domain/Review.java
@@ -49,7 +49,7 @@ public class Review {
         return new Review(null, shelter, user, photoUrl, title, content, rating, createdAt, updatedAt);
     }
 
-    private Review(Long reviewId, Shelter shelter, User user, String photoUrl, String title, String title, int rating, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    private Review(Long reviewId, Shelter shelter, User user, String photoUrl, String title, String content, int rating, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.reviewId = reviewId;
         this.shelter = shelter;
         this.user = user;

--- a/src/main/java/com/team19/musuimsa/review/domain/Review.java
+++ b/src/main/java/com/team19/musuimsa/review/domain/Review.java
@@ -1,0 +1,63 @@
+package com.team19.musuimsa.review.domain;
+
+import com.team19.musuimsa.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "reviews")
+@Getter
+@NoArgsConstructor
+public class Review {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reviewId;
+
+    @ManyToOne
+    private Shelter shelter;
+
+    @ManyToOne
+    private User user;
+
+    private String photoUrl;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private int rating;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static Review of(Shelter shelter, User user, String photoUrl, String title, String content, int rating, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        return new Review(null, shelter, user, photoUrl, title, content, rating, createdAt, updatedAt);
+    }
+
+    private Review(Long reviewId, Shelter shelter, User user, String photoUrl, String title, String title, int rating, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.reviewId = reviewId;
+        this.shelter = shelter;
+        this.user = user;
+        this.photoUrl = photoUrl;
+        this.title = title;
+        this.content = content;
+        this.rating = rating;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/team19/musuimsa/review/domain/Review.java
+++ b/src/main/java/com/team19/musuimsa/review/domain/Review.java
@@ -1,14 +1,16 @@
 package com.team19.musuimsa.review.domain;
 
+import com.team19.musuimsa.dateTime.BaseEntity;
 import com.team19.musuimsa.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,16 +18,18 @@ import lombok.NoArgsConstructor;
 @Table(name = "reviews")
 @Getter
 @NoArgsConstructor
-public class Review {
+public class Review extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long reviewId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "shelter_id", nullable = false)
     private Shelter shelter;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     private String photoUrl;
@@ -33,23 +37,19 @@ public class Review {
     @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "text")
     private String content;
 
     @Column(nullable = false)
     private int rating;
 
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(nullable = false)
-    private LocalDateTime updatedAt;
-
-    public static Review of(Shelter shelter, User user, String photoUrl, String title, String content, int rating, LocalDateTime createdAt, LocalDateTime updatedAt) {
-        return new Review(null, shelter, user, photoUrl, title, content, rating, createdAt, updatedAt);
+    public static Review of(Shelter shelter, User user, String photoUrl, String title,
+            String content, int rating) {
+        return new Review(null, shelter, user, photoUrl, title, content, rating);
     }
 
-    private Review(Long reviewId, Shelter shelter, User user, String photoUrl, String title, String content, int rating, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    private Review(Long reviewId, Shelter shelter, User user, String photoUrl, String title,
+            String content, int rating) {
         this.reviewId = reviewId;
         this.shelter = shelter;
         this.user = user;
@@ -57,7 +57,24 @@ public class Review {
         this.title = title;
         this.content = content;
         this.rating = rating;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
     }
+
+    public void update(String title, String content, Integer rating, String photoUrl) {
+        if (title != null) {
+            this.title = title;
+        }
+
+        if (content != null) {
+            this.content = content;
+        }
+
+        if (rating != null) {
+            this.rating = rating;
+        }
+
+        if (photoUrl != null) {
+            this.photoUrl = photoUrl;
+        }
+    }
+
 }

--- a/src/main/java/com/team19/musuimsa/review/dto/CreateReviewRequest.java
+++ b/src/main/java/com/team19/musuimsa/review/dto/CreateReviewRequest.java
@@ -1,0 +1,11 @@
+package com.team19.musuimsa.review.dto;
+
+
+public record CreateReviewRequest(
+        String title,
+        String content,
+        int rating,
+        String photoUrl
+) {
+
+}

--- a/src/main/java/com/team19/musuimsa/review/dto/CreateReviewResponse.java
+++ b/src/main/java/com/team19/musuimsa/review/dto/CreateReviewResponse.java
@@ -1,0 +1,14 @@
+package com.team19.musuimsa.review.dto;
+
+import com.team19.musuimsa.user.domain.User;
+import java.time.LocalDateTime;
+
+public record CreateReviewResponse(
+        Long reviewId,
+        Long shelterId,
+        Long userId,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+}

--- a/src/main/java/com/team19/musuimsa/review/dto/ReviewDto.java
+++ b/src/main/java/com/team19/musuimsa/review/dto/ReviewDto.java
@@ -1,0 +1,27 @@
+package com.team19.musuimsa.review.dto;
+
+import java.time.LocalDateTime;
+
+public record ReviewDto(
+
+        Long reviewId,
+
+        Long shelterId,
+
+        Long userId,
+
+        String nickname,
+
+        String title,
+
+        String content,
+
+        int rating,
+
+        String photoUrl,
+
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+}

--- a/src/main/java/com/team19/musuimsa/review/dto/UpdateReviewRequest.java
+++ b/src/main/java/com/team19/musuimsa/review/dto/UpdateReviewRequest.java
@@ -1,0 +1,10 @@
+package com.team19.musuimsa.review.dto;
+
+public record UpdateReviewRequest(
+        String title,
+        String content,
+        int rating,
+        String photoUrl
+) {
+
+}

--- a/src/main/java/com/team19/musuimsa/review/repository/ReviewRepository.java
+++ b/src/main/java/com/team19/musuimsa/review/repository/ReviewRepository.java
@@ -1,0 +1,14 @@
+package com.team19.musuimsa.review.repository;
+
+import com.team19.musuimsa.review.domain.Review;
+import com.team19.musuimsa.user.domain.User;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    List<Review> findByShelter(Shelter shelter);
+
+    List<Review> findByUser(User user);
+
+}

--- a/src/main/java/com/team19/musuimsa/review/repository/ReviewRepository.java
+++ b/src/main/java/com/team19/musuimsa/review/repository/ReviewRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-    List<Review> findByShelter(Shelter shelter);
+    List<Review> findByShelterOrderByCreatedAtDesc(Shelter shelter);
 
     List<Review> findByUser(User user);
 

--- a/src/main/java/com/team19/musuimsa/review/service/ReviewService.java
+++ b/src/main/java/com/team19/musuimsa/review/service/ReviewService.java
@@ -1,0 +1,117 @@
+package com.team19.musuimsa.review.service;
+
+import com.team19.musuimsa.exception.notfound.ReviewNotFoundException;
+import com.team19.musuimsa.exception.notfound.ShelterNotFoundException;
+import com.team19.musuimsa.exception.notfound.UserNotFoundException;
+import com.team19.musuimsa.review.domain.Review;
+import com.team19.musuimsa.review.dto.CreateReviewRequest;
+import com.team19.musuimsa.review.dto.CreateReviewResponse;
+import com.team19.musuimsa.review.dto.ReviewDto;
+import com.team19.musuimsa.review.dto.UpdateReviewRequest;
+import com.team19.musuimsa.review.repository.ReviewRepository;
+import com.team19.musuimsa.user.domain.User;
+import com.team19.musuimsa.user.repository.UserRepository;
+import java.nio.file.AccessDeniedException;
+import java.util.List;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final ShelterRepository shelterRepository;
+    private final UserRepository userRepository;
+
+    public ReviewService(ReviewRepository reviewRepository, ShelterRepository shelterRepository,
+            UserRepository userRepository) {
+        this.reviewRepository = reviewRepository;
+        this.shelterRepository = shelterRepository;
+        this.userRepository = userRepository;
+    }
+
+    // 리뷰 생성
+    @Transactional
+    public CreateReviewResponse createReview(Long shelterId, CreateReviewRequest request,
+            @AuthenticationPrincipal User user) {
+        Shelter shelter = shelterRepository.findById(shelterId)
+                .orElseThrow(() -> new ShelterNotFoundException(shelterId));
+
+        Review review = Review.of(shelter, user, request.photoUrl(), request.title(),
+                request.content(), request.rating());
+
+        reviewRepository.save(review);
+
+        CreateReviewResponse response = new CreateReviewResponse(review.getReviewId(),
+                review.getShelter().getShelterId(), review.getUser().getUserId(),
+                review.getCreatedAt(), review.getUpdatedAt());
+
+        return response;
+    }
+
+    // 리뷰 수정
+    @Transactional
+    public ReviewDto updateReview(Long reviewId, UpdateReviewRequest request,
+            @AuthenticationPrincipal User user)
+            throws AccessDeniedException {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new ReviewNotFoundException(reviewId));
+
+        if (!review.getUser().equals(user)) {
+            throw new AccessDeniedException("자신의 리뷰만 수정할 수 있습니다.");
+        }
+
+        review.update(request.title(), request.content(), request.rating(), request.photoUrl());
+
+        return toDto(review);
+
+    }
+
+    // 리뷰 삭제
+    public void deleteReview(Long reviewId, @AuthenticationPrincipal User user)
+            throws AccessDeniedException {
+        Review review = reviewRepository.findById(reviewId).orElseThrow(
+                () -> new ReviewNotFoundException(reviewId));
+
+        if (!review.getUser().equals(user)) {
+            throw new AccessDeniedException("자신의 리뷰만 삭제할 수 있습니다.");
+        }
+
+        reviewRepository.delete(review);
+    }
+
+    // 쉼터별 리뷰 조회
+    public List<ReviewDto> getReviewsByShelter(Long shelterId) {
+        Shelter shelter = shelterRepository.findById(shelterId)
+                .orElseThrow(() -> new ShelterNotFoundException(shelterId));
+
+        List<Review> reviews = reviewRepository.findByShelterOrderByCreatedAtDesc(shelter);
+
+        return reviews.stream()
+                .map(this::toDto)
+                .toList();
+    }
+
+    // 사용자별 리뷰 조회
+    public List<ReviewDto> getReviewsByUser(@AuthenticationPrincipal User user) {
+        User loginUser = userRepository.findById(user.getUserId())
+                .orElseThrow(() -> new UserNotFoundException(user.getUserId()));
+
+        List<Review> reviews = reviewRepository.findByUser(user);
+
+        return reviews.stream()
+                .map(this::toDto)
+                .toList();
+    }
+
+    private ReviewDto toDto(Review review) {
+        return new ReviewDto(
+                review.getReviewId(), review.getShelter().getShelterId(),
+                review.getUser().getUserId(), review.getUser().getNickname(), review.getTitle(),
+                review.getContent(), review.getRating(), review.getPhotoUrl(),
+                review.getCreatedAt(), review.getUpdatedAt()
+        );
+    }
+}


### PR DESCRIPTION
**논의해 볼 점**
- 리뷰 제목, 내용 길이
- 한 사용자가 한 쉼터에 하나의 리뷰만 쓰게 해야 할까?
- 리뷰 조회 방법은 두 가지지만, 응답 형식은 하나로 통일하는 게 어떨지(그렇게 하면 각각 쉼터아이디, 유저아이디 하나씩만 추가됨)
- userId를 api 경로에 넣기보단, 로그인 한 경우의 엔드포인트를 /me 로 두고 현재 로그인 중인 사용자의 아이디를 받아와서 사용하는 게 어떨지 (보안에 더 좋을 듯 합니다.)
- 리뷰 조회 시 정렬순 확장 가능