### PR TITLE
[Week5] Shelter 멘토님 피드백 반영

### DIFF
--- a/src/main/java/com/team19/musuimsa/config/WebClientConfig.java
+++ b/src/main/java/com/team19/musuimsa/config/WebClientConfig.java
@@ -2,6 +2,7 @@ package com.team19.musuimsa.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
@@ -9,6 +10,10 @@ public class WebClientConfig {
 
     @Bean
     public WebClient webClient(WebClient.Builder builder) {
-        return builder.build();
+        return builder
+                .exchangeStrategies(ExchangeStrategies.builder()
+                        .codecs(c -> c.defaultCodecs().maxInMemorySize(10 * 1024 * 1024))
+                        .build())
+                .build();
     }
 }

--- a/src/main/java/com/team19/musuimsa/config/WebClientConfig.java
+++ b/src/main/java/com/team19/musuimsa/config/WebClientConfig.java
@@ -7,8 +7,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Configuration
 public class WebClientConfig {
 
-    @Bean("shelterWebClient")
-    public WebClient shelterWebClient(WebClient.Builder builder) {
+    @Bean
+    public WebClient webClient(WebClient.Builder builder) {
         return builder.build();
     }
 }

--- a/src/main/java/com/team19/musuimsa/shelter/controller/ShelterAdminController.java
+++ b/src/main/java/com/team19/musuimsa/shelter/controller/ShelterAdminController.java
@@ -1,33 +1,22 @@
 package com.team19.musuimsa.shelter.controller;
 
-import com.team19.musuimsa.shelter.domain.Shelter;
 import com.team19.musuimsa.shelter.service.ShelterImportService;
-import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/admin/shelters")
 @RequiredArgsConstructor
-@Validated
 public class ShelterAdminController {
 
     private final ShelterImportService importService;
 
-    // 외부 응답/매핑만 확인(저장 X)
-    @GetMapping("/preview")
-    public ResponseEntity<List<Shelter>> preview(@RequestParam(defaultValue = "1") @Positive int page) {
-        return ResponseEntity.ok(importService.previewPage(page));
-    }
-
-    // 전체 페이지 1회 업서트
-    @PostMapping("/import-once")
-    public ResponseEntity<String> importOnce() {
-        int count = importService.importOnce();
-        return ResponseEntity.ok("Upserted shelters = " + count);
+    @PostMapping("/import")
+    public ResponseEntity<Integer> importShelters() {
+        int saved = importService.importOnce();
+        return ResponseEntity.ok(saved);
     }
 }

--- a/src/main/java/com/team19/musuimsa/shelter/controller/ShelterController.java
+++ b/src/main/java/com/team19/musuimsa/shelter/controller/ShelterController.java
@@ -1,36 +1,33 @@
 package com.team19.musuimsa.shelter.controller;
 
 import com.team19.musuimsa.shelter.dto.NearbyShelterResponse;
-import com.team19.musuimsa.shelter.dto.ShelterDetailResponse;
+import com.team19.musuimsa.shelter.dto.ShelterResponse;
 import com.team19.musuimsa.shelter.service.ShelterService;
-import jakarta.validation.constraints.*;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/shelters")
 @RequiredArgsConstructor
-@Validated
 public class ShelterController {
 
     private final ShelterService shelterService;
 
-    // 가까운 쉼터 조회 (Nearby): default 3000 (3km 이내)
+    // 가까운 쉼터 조회
     @GetMapping("/nearby")
-    public ResponseEntity<List<NearbyShelterResponse>> nearby(
-            @RequestParam @NotNull @DecimalMin(value = "-90.0") @DecimalMax("90.0") Double latitude,
-            @RequestParam @NotNull @DecimalMin(value = "-180.0") @DecimalMax("180.0") Double longitude,
-            @RequestParam(required = false, defaultValue = "3000") @Positive Double radius
+    public ResponseEntity<List<NearbyShelterResponse>> findNearbyShelters(
+            @RequestParam double latitude,
+            @RequestParam double longitude
     ) {
-        return ResponseEntity.ok(shelterService.findNearby(latitude, longitude, radius));
+        return ResponseEntity.ok(shelterService.findNearbyShelters(latitude, longitude));
     }
 
     // 쉼터 상세 조회
     @GetMapping("/{shelterId}")
-    public ResponseEntity<ShelterDetailResponse> detail(@PathVariable Long shelterId) {
+    public ResponseEntity<ShelterResponse> getShelter(@PathVariable Long shelterId) {
         return ResponseEntity.ok(shelterService.getShelter(shelterId));
     }
 }

--- a/src/main/java/com/team19/musuimsa/shelter/domain/Shelter.java
+++ b/src/main/java/com/team19/musuimsa/shelter/domain/Shelter.java
@@ -1,63 +1,74 @@
 package com.team19.musuimsa.shelter.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import java.math.BigDecimal;
 import java.time.LocalTime;
-import lombok.*;
 
 @Entity
-@Table(name = "shelters")
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Table(name = "shelters")
 public class Shelter {
 
+    // RSTR_FCLTY_NO
     @Id
-    private Long shelterId; // PK: RSTR_FCLTY_NO
+    private Long shelterId;
 
+    // RSTR_NM
     @Column(nullable = false, length = 100)
-    private String name; // RSTR_NM
+    private String name;
 
-    @Column(length = 255)
-    private String photoUrl;
+    // DTL_ADRES
+    @Column(nullable = false, length = 100)
+    private String address;
 
-    @Column(nullable = false, length = 255)
-    private String address; // RN_DTL_ADRES
-
+    // LA
     @Column(nullable = false, precision = 10, scale = 8)
-    private BigDecimal latitude; // LA
+    private BigDecimal latitude;
 
+    // LO
     @Column(nullable = false, precision = 11, scale = 8)
-    private BigDecimal longitude; // LO
+    private BigDecimal longitude;
 
-    private Integer capacity; // USE_PSBL_NMPR
+    // WKDAY_OPER_BEGIN_TIME
+    private LocalTime weekdayOpenTime;
 
-    private Integer fanCount; // COLR_HOLD_ELFN
+    // WKDAY_OPER_END_TIME
+    private LocalTime weekdayCloseTime;
 
-    private Integer airConditionerCount; // COLR_HOLD_ARCDTN
+    // WKEND_HDAY_OPER_BEGIN_TIME
+    private LocalTime weekendOpenTime;
 
-    private Boolean isOutdoors; // FCLTY_TY == '002' → true
+    // WKEND_HDAY_OPER_END_TIME
+    private LocalTime weekendCloseTime;
 
-    private LocalTime weekdayOpenTime; // WKDAY_OPER_BEGIN_TIME
+    // USE_PSBL_NMPR
+    private Integer capacity;
 
-    private LocalTime weekdayCloseTime; // WKDAY_OPER_END_TIME
+    // FCLTY_TY == '002' → true
+    private Boolean isOutdoors;
 
-    private LocalTime weekendOpenTime; // WKEND_HDAY_OPER_BEGIN_TIME
+    // COLR_HOLD_ELFN
+    private Integer fanCount;
 
-    private LocalTime weekendCloseTime; // WKEND_HDAY_OPER_END_TIME
+    // COLR_HOLD_ARCNDTN
+    private Integer airConditionerCount;
 
     private Integer totalRating;
 
     private Integer reviewCount;
 
-    @PrePersist
-    void initDefaults() {
-        if (totalRating == null) {
-            totalRating = 0;
-        }
-        if (reviewCount == null) {
-            reviewCount = 0;
-        }
-    }
+    @Column(length = 255)
+    private String photoUrl;
+
 }

--- a/src/main/java/com/team19/musuimsa/shelter/dto/NearbyShelterResponse.java
+++ b/src/main/java/com/team19/musuimsa/shelter/dto/NearbyShelterResponse.java
@@ -1,17 +1,14 @@
 package com.team19.musuimsa.shelter.dto;
 
-import java.util.Map;
-
 public record NearbyShelterResponse(
         Long shelterId,
         String name,
         String address,
-        double latitude,
-        double longitude,
-        String distance,
-        boolean isOpened,
-        boolean isOutdoors,
-        Map<String, String> operatingHours,
-        double averageRating, // 소수 1자리
+        Double latitude,
+        Double longitude,
+        Boolean isOutdoors,
+        OperatingHoursResponse operatingHoursResponse,
+        Double averageRating,
         String photoUrl
-) {}
+) {
+}

--- a/src/main/java/com/team19/musuimsa/shelter/dto/OperatingHoursResponse.java
+++ b/src/main/java/com/team19/musuimsa/shelter/dto/OperatingHoursResponse.java
@@ -1,0 +1,7 @@
+package com.team19.musuimsa.shelter.dto;
+
+public record OperatingHoursResponse(
+        String weekday,
+        String weekend
+) {
+}

--- a/src/main/java/com/team19/musuimsa/shelter/dto/ShelterResponse.java
+++ b/src/main/java/com/team19/musuimsa/shelter/dto/ShelterResponse.java
@@ -1,17 +1,14 @@
 package com.team19.musuimsa.shelter.dto;
 
-import java.util.Map;
-
-public record ShelterDetailResponse(
+public record ShelterResponse(
         Long shelterId,
         String name,
         String address,
-        double latitude,
-        double longitude,
-        Map<String, String> operatingHours,
+        Double latitude,
+        Double longitude,
+        OperatingHoursResponse operatingHoursResponse,
         Integer capacity,
-        boolean isOpened,
-        boolean isOutdoors,
+        Boolean isOutdoors,
         CoolingEquipment coolingEquipment,
         Integer totalRating,
         Integer reviewCount,
@@ -19,6 +16,7 @@ public record ShelterDetailResponse(
 ) {
     public record CoolingEquipment(
             Integer fanCount,
-            Integer acCount
-    ) {}
+            Integer airConditionerCount
+    ) {
+    }
 }

--- a/src/main/java/com/team19/musuimsa/shelter/dto/external/ExternalResponse.java
+++ b/src/main/java/com/team19/musuimsa/shelter/dto/external/ExternalResponse.java
@@ -1,7 +1,10 @@
 package com.team19.musuimsa.shelter.dto.external;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.List;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record ExternalResponse(
         Header header,
         Integer numOfRows,
@@ -9,6 +12,7 @@ public record ExternalResponse(
         Integer totalCount,
         List<ExternalShelterItem> body
 ) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public record Header(
             String resultMsg,
             String resultCode,

--- a/src/main/java/com/team19/musuimsa/shelter/dto/external/ExternalShelterItem.java
+++ b/src/main/java/com/team19/musuimsa/shelter/dto/external/ExternalShelterItem.java
@@ -1,18 +1,50 @@
 package com.team19.musuimsa.shelter.dto.external;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record ExternalShelterItem(
-        String RSTR_FCLTY_NO,
-        String RSTR_NM,
-        String RN_DTL_ADRES,
-        String LA,
-        String LO,
-        String USE_PSBL_NMPR,
-        String COLR_HOLD_ELFN,
-        String COLR_HOLD_ARCDTN,
-        String WKDAY_OPER_BEGIN_TIME,
-        String WKDAY_OPER_END_TIME,
-        String WKEND_HDAY_OPER_BEGIN_TIME,
-        String WKEND_HDAY_OPER_END_TIME,
-        String FCLTY_TY,
-        String PHOTO_URL
-) {}
+        @JsonProperty("RSTR_FCLTY_NO")
+        Long rstrFcltyNo,
+
+        @JsonProperty("RSTR_NM")
+        String rstrNm,
+
+        @JsonProperty("RN_DTL_ADRES")
+        String rnDtlAdres,
+
+        @JsonProperty("LA")
+        BigDecimal la,
+
+        @JsonProperty("LO")
+        BigDecimal lo,
+
+        @JsonProperty("USE_PSBL_NMPR")
+        Integer usePsblNmpr,
+
+        @JsonProperty("COLR_HOLD_ELEFN")
+        Integer colrHoldElefn,
+
+        @JsonProperty("COLR_HOLD_ARCNDTN")
+        Integer colrHoldArcdtn,
+
+        @JsonProperty("WKDAY_OPER_BEGIN_TIME")
+        String wkdayOperBeginTime,
+
+        @JsonProperty("WKDAY_OPER_END_TIME")
+        String wkdayOperEndTime,
+
+        @JsonProperty("WKEND_HDAY_OPER_BEGIN_TIME")
+        String wkendHdayOperBeginTime,
+
+        @JsonProperty("WKEND_HDAY_OPER_END_TIME")
+        String wkendHdayOperEndTime,
+
+        @JsonProperty("FCLTY_TY")
+        String fcltyTy
+) {
+}
+

--- a/src/main/java/com/team19/musuimsa/shelter/repository/ShelterRepository.java
+++ b/src/main/java/com/team19/musuimsa/shelter/repository/ShelterRepository.java
@@ -1,66 +1,31 @@
 package com.team19.musuimsa.shelter.repository;
 
 import com.team19.musuimsa.shelter.domain.Shelter;
-
-import java.math.BigDecimal;
-import java.util.List;
-import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ShelterRepository extends JpaRepository<Shelter, Long> {
 
-    /**
-     * Haversine (미터). 반경 내 정렬 + 상한 100.
-     * RDB: MySQL/H2 모두 동작 가능한 식 사용
-     */
     @Query(value = """
-    SELECT
-      t.shelterId, t.name, t.address, t.latitude, t.longitude, t.isOutdoors,
-      t.weekdayOpenTime, t.weekdayCloseTime, t.weekendOpenTime, t.weekendCloseTime,
-      t.totalRating, t.reviewCount, t.photoUrl, t.distanceM
-    FROM (
-      SELECT s.shelter_id AS shelterId,
-             s.name AS name,
-             s.address AS address,
-             s.latitude AS latitude,
-             s.longitude AS longitude,
-             s.is_outdoors AS isOutdoors,
-             s.weekday_open_time AS weekdayOpenTime,
-             s.weekday_close_time AS weekdayCloseTime,
-             s.weekend_open_time AS weekendOpenTime,
-             s.weekend_close_time AS weekendCloseTime,
-             s.total_rating AS totalRating,
-             s.review_count AS reviewCount,
-             s.photo_url AS photoUrl,
-             (6371000 * acos(
-                 cos(radians(:lat)) * cos(radians(s.latitude)) *
-                 cos(radians(s.longitude) - radians(:lon)) +
-                 sin(radians(:lat)) * sin(radians(s.latitude))
-             )) AS distanceM
-      FROM shelters s
-    ) t
-    WHERE t.distanceM <= :radius
-    ORDER BY t.distanceM ASC
-    LIMIT 100
-    """, nativeQuery = true)
-    List<ShelterNearbyRow> findNearby(@Param("lat") double lat,
-                                      @Param("lon") double lon,
-                                      @Param("radius") double radiusMeters);
-
-    interface ShelterNearbyRow {
-        Long getShelterId();
-        String getName();
-        String getAddress();
-        BigDecimal getLatitude();
-        BigDecimal getLongitude();
-        Boolean getIsOutdoors();
-        java.sql.Time getWeekdayOpenTime();
-        java.sql.Time getWeekdayCloseTime();
-        java.sql.Time getWeekendOpenTime();
-        java.sql.Time getWeekendCloseTime();
-        Integer getTotalRating();
-        Integer getReviewCount();
-        String getPhotoUrl();
-        Double getDistanceM();
-    }
+            SELECT s.*
+            FROM shelters s
+            WHERE (6371000 * ACOS(
+                     COS(RADIANS(:lat)) * COS(RADIANS(s.latitude)) *
+                     COS(RADIANS(s.longitude) - RADIANS(:lng)) +
+                     SIN(RADIANS(:lat)) * SIN(RADIANS(s.latitude))
+                  )) <= :radius
+            ORDER BY (6371000 * ACOS(
+                     COS(RADIANS(:lat)) * COS(RADIANS(s.latitude)) *
+                     COS(RADIANS(s.longitude) - RADIANS(:lng)) +
+                     SIN(RADIANS(:lat)) * SIN(RADIANS(s.latitude))
+                  ))
+            """, nativeQuery = true)
+    List<Shelter> findNearbyShelters(
+            @Param("lat") double lat,
+            @Param("lng") double lng,
+            @Param("radius") int radius
+    );
 }

--- a/src/main/java/com/team19/musuimsa/shelter/service/ShelterOpenApiClient.java
+++ b/src/main/java/com/team19/musuimsa/shelter/service/ShelterOpenApiClient.java
@@ -1,14 +1,15 @@
 package com.team19.musuimsa.shelter.service;
 
-import com.team19.musuimsa.exception.external.ExternalApiException;
 import com.team19.musuimsa.shelter.dto.external.ExternalResponse;
-import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
 
 @Slf4j
 @Component
@@ -30,37 +31,24 @@ public class ShelterOpenApiClient {
     @Value("${musuimsa.shelter.api.format}")
     private String format;
 
-    private final @Qualifier("shelterWebClient")
-    WebClient webClient;
+    @Qualifier("shelterWebClient")
+    private final WebClient shelterWebClient;
 
     public ExternalResponse fetchPage(int pageNo) {
-        String url = baseUrl + path;
-        try {
-            return webClient.get()
-                    .uri(uri -> uri
-                            .path(url.replaceFirst("^https?://[^/]+", ""))
-                            .queryParam("serviceKey", serviceKey)
-                            .queryParam("pageNo", pageNo)
-                            .queryParam("numOfRows", pageSize)
-                            .queryParam("returnType", format)
-                            .build())
-                    .retrieve()
-                    .bodyToMono(ExternalResponse.class)
-                    .block();
-        } catch (Exception e) {
-            String full = String.format("%s%s?pageNo=%d&numOfRows=%d&returnType=%s",
-                    baseUrl, path, pageNo, pageSize, format);
-            throw new ExternalApiException(full, e);
-        }
-    }
+        URI uri = UriComponentsBuilder
+                .fromHttpUrl(baseUrl)
+                .path(path)
+                .queryParam("serviceKey", serviceKey)
+                .queryParam("pageNo", pageNo)
+                .queryParam("numOfRows", pageSize)
+                .queryParam("returnType", format)
+                .build(true)
+                .toUri();
 
-    public int pageSize() {
-        return pageSize;
-    }
-
-    @PostConstruct
-    void logConf() {
-        log.info("[ShelterAPI] keyLen={}, base={}, path={}, pageSize={}",
-                (serviceKey == null ? 0 : serviceKey.length()), baseUrl, path, pageSize);
+        return shelterWebClient.get()
+                .uri(uri)
+                .retrieve()
+                .bodyToMono(ExternalResponse.class)
+                .block();
     }
 }

--- a/src/main/java/com/team19/musuimsa/shelter/service/ShelterOpenApiClient.java
+++ b/src/main/java/com/team19/musuimsa/shelter/service/ShelterOpenApiClient.java
@@ -3,7 +3,6 @@ package com.team19.musuimsa.shelter.service;
 import com.team19.musuimsa.shelter.dto.external.ExternalResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -31,8 +30,7 @@ public class ShelterOpenApiClient {
     @Value("${musuimsa.shelter.api.format}")
     private String format;
 
-    @Qualifier("shelterWebClient")
-    private final WebClient shelterWebClient;
+    private final WebClient webClient;
 
     public ExternalResponse fetchPage(int pageNo) {
         URI uri = UriComponentsBuilder
@@ -45,7 +43,7 @@ public class ShelterOpenApiClient {
                 .build(true)
                 .toUri();
 
-        return shelterWebClient.get()
+        return webClient.get()
                 .uri(uri)
                 .retrieve()
                 .bodyToMono(ExternalResponse.class)

--- a/src/main/java/com/team19/musuimsa/shelter/service/ShelterService.java
+++ b/src/main/java/com/team19/musuimsa/shelter/service/ShelterService.java
@@ -3,13 +3,12 @@ package com.team19.musuimsa.shelter.service;
 import com.team19.musuimsa.exception.notfound.ShelterNotFoundException;
 import com.team19.musuimsa.shelter.domain.Shelter;
 import com.team19.musuimsa.shelter.dto.NearbyShelterResponse;
-import com.team19.musuimsa.shelter.dto.OperatingHoursResponse;
 import com.team19.musuimsa.shelter.dto.ShelterResponse;
 import com.team19.musuimsa.shelter.repository.ShelterRepository;
+import com.team19.musuimsa.shelter.util.ShelterDtoUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalTime;
 import java.util.List;
 
 @Service
@@ -21,23 +20,9 @@ public class ShelterService {
     private final ShelterRepository shelterRepository;
 
     public List<NearbyShelterResponse> findNearbyShelters(double latitude, double longitude) {
-        List<Shelter> shelters = shelterRepository.findNearbyShelters(latitude, longitude, DEFAULT_RADIUS);
-
-        return shelters.stream()
-                .map(s -> new NearbyShelterResponse(
-                        s.getShelterId(),
-                        s.getName(),
-                        s.getAddress(),
-                        s.getLatitude().doubleValue(),
-                        s.getLongitude().doubleValue(),
-                        s.getIsOutdoors(),
-                        new OperatingHoursResponse(
-                                formatHours(s.getWeekdayOpenTime(), s.getWeekdayCloseTime()),
-                                formatHours(s.getWeekendOpenTime(), s.getWeekendCloseTime())
-                        ),
-                        calcAverageRating(s.getTotalRating(), s.getReviewCount()),
-                        s.getPhotoUrl()
-                ))
+        return shelterRepository.findNearbyShelters(latitude, longitude, DEFAULT_RADIUS)
+                .stream()
+                .map(ShelterDtoUtils::toNearbyDto)
                 .toList();
     }
 
@@ -45,52 +30,6 @@ public class ShelterService {
         Shelter s = shelterRepository.findById(shelterId)
                 .orElseThrow(() -> new ShelterNotFoundException(shelterId));
 
-        return new ShelterResponse(
-                s.getShelterId(),
-                s.getName(),
-                s.getAddress(),
-                s.getLatitude().doubleValue(),
-                s.getLongitude().doubleValue(),
-                new OperatingHoursResponse(
-                        formatHours(s.getWeekdayOpenTime(), s.getWeekdayCloseTime()),
-                        formatHours(s.getWeekendOpenTime(), s.getWeekendCloseTime())
-                ),
-                s.getCapacity(),
-                s.getIsOutdoors(),
-                new ShelterResponse.CoolingEquipment(
-                        s.getFanCount(),
-                        s.getAirConditionerCount()
-                ),
-                s.getTotalRating(),
-                s.getReviewCount(),
-                s.getPhotoUrl()
-        );
-    }
-
-    // 둘 다 null -> "" (빈 문자열)
-    // open null -> "~HH:mm"
-    // close null -> "HH:mm~"
-    // 둘 다 존재 -> "HH:mm~HH:mm"
-    private String formatHours(LocalTime open, LocalTime close) {
-        if (open == null && close == null) {
-            return "";
-        }
-
-        String start = (open != null) ? toHHmm(open) : "";
-        String end = (close != null) ? toHHmm(close) : "";
-
-        return start + "~" + end;
-    }
-
-    private String toHHmm(LocalTime t) {
-        return String.format("%02d:%02d", t.getHour(), t.getMinute());
-    }
-
-    private Double calcAverageRating(Integer totalRating, Integer reviewCount) {
-        if (reviewCount == null || reviewCount == 0 || totalRating == null) {
-            return 0.0;
-        }
-
-        return totalRating.doubleValue() / reviewCount;
+        return ShelterDtoUtils.toDetailDto(s);
     }
 }

--- a/src/main/java/com/team19/musuimsa/shelter/service/ShelterService.java
+++ b/src/main/java/com/team19/musuimsa/shelter/service/ShelterService.java
@@ -3,143 +3,94 @@ package com.team19.musuimsa.shelter.service;
 import com.team19.musuimsa.exception.notfound.ShelterNotFoundException;
 import com.team19.musuimsa.shelter.domain.Shelter;
 import com.team19.musuimsa.shelter.dto.NearbyShelterResponse;
-import com.team19.musuimsa.shelter.dto.ShelterDetailResponse;
+import com.team19.musuimsa.shelter.dto.OperatingHoursResponse;
+import com.team19.musuimsa.shelter.dto.ShelterResponse;
 import com.team19.musuimsa.shelter.repository.ShelterRepository;
-import java.time.*;
-import java.time.format.DateTimeFormatter;
-import java.util.*;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ShelterService {
 
-    private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+    private static final int DEFAULT_RADIUS = 1000;
 
     private final ShelterRepository shelterRepository;
 
-    public List<NearbyShelterResponse> findNearby(double lat, double lon, double radiusMeters) {
-        List<ShelterRepository.ShelterNearbyRow> rows = shelterRepository.findNearby(lat, lon, radiusMeters);
-        LocalDateTime now = LocalDateTime.now(ZONE);
+    public List<NearbyShelterResponse> findNearbyShelters(double latitude, double longitude) {
+        List<Shelter> shelters = shelterRepository.findNearbyShelters(latitude, longitude, DEFAULT_RADIUS);
 
-        return rows.stream().map(r -> {
-            boolean opened = isOpened(
-                    toLocalTime(r.getWeekdayOpenTime()), toLocalTime(r.getWeekdayCloseTime()),
-                    toLocalTime(r.getWeekendOpenTime()), toLocalTime(r.getWeekendCloseTime()),
-                    now);
-
-            double avg = calcAverage(r.getTotalRating(), r.getReviewCount());
-            String distance = formatDistance(r.getDistanceM());
-
-            Map<String, String> hours = Map.of(
-                    "weekday", formatHours(toLocalTime(r.getWeekdayOpenTime()), toLocalTime(r.getWeekdayCloseTime())),
-                    "weekend", formatHours(toLocalTime(r.getWeekendOpenTime()), toLocalTime(r.getWeekendCloseTime()))
-            );
-
-            double latitude = (r.getLatitude()  == null) ? 0.0 : r.getLatitude().doubleValue();
-            double longitude = (r.getLongitude() == null) ? 0.0 : r.getLongitude().doubleValue();
-
-            return new NearbyShelterResponse(
-                    r.getShelterId(),
-                    r.getName(),
-                    r.getAddress(),
-                    latitude,
-                    longitude,
-                    distance,
-                    opened,
-                    Boolean.TRUE.equals(r.getIsOutdoors()),
-                    hours,
-                    avg,
-                    r.getPhotoUrl()
-            );
-        }).collect(Collectors.toList());
+        return shelters.stream()
+                .map(s -> new NearbyShelterResponse(
+                        s.getShelterId(),
+                        s.getName(),
+                        s.getAddress(),
+                        s.getLatitude().doubleValue(),
+                        s.getLongitude().doubleValue(),
+                        s.getIsOutdoors(),
+                        new OperatingHoursResponse(
+                                formatHours(s.getWeekdayOpenTime(), s.getWeekdayCloseTime()),
+                                formatHours(s.getWeekendOpenTime(), s.getWeekendCloseTime())
+                        ),
+                        calcAverageRating(s.getTotalRating(), s.getReviewCount()),
+                        s.getPhotoUrl()
+                ))
+                .toList();
     }
 
-    public ShelterDetailResponse getShelter(Long shelterId) {
+    public ShelterResponse getShelter(Long shelterId) {
         Shelter s = shelterRepository.findById(shelterId)
                 .orElseThrow(() -> new ShelterNotFoundException(shelterId));
 
-        LocalDateTime now = LocalDateTime.now(ZONE);
-        boolean opened = isOpened(
-                s.getWeekdayOpenTime(), s.getWeekdayCloseTime(),
-                s.getWeekendOpenTime(), s.getWeekendCloseTime(),
-                now);
-
-        Map<String, String> hours = Map.of(
-                "weekday", formatHours(s.getWeekdayOpenTime(), s.getWeekdayCloseTime()),
-                "weekend", formatHours(s.getWeekendOpenTime(), s.getWeekendCloseTime())
-        );
-
-        double latitude = (s.getLatitude()  == null) ? 0.0 : s.getLatitude().doubleValue();
-        double longitude = (s.getLongitude() == null) ? 0.0 : s.getLongitude().doubleValue();
-
-        return new ShelterDetailResponse(
+        return new ShelterResponse(
                 s.getShelterId(),
                 s.getName(),
                 s.getAddress(),
-                latitude,
-                longitude,
-                hours,
+                s.getLatitude().doubleValue(),
+                s.getLongitude().doubleValue(),
+                new OperatingHoursResponse(
+                        formatHours(s.getWeekdayOpenTime(), s.getWeekdayCloseTime()),
+                        formatHours(s.getWeekendOpenTime(), s.getWeekendCloseTime())
+                ),
                 s.getCapacity(),
-                opened,
-                Boolean.TRUE.equals(s.getIsOutdoors()),
-                new ShelterDetailResponse.CoolingEquipment(s.getFanCount(), s.getAirConditionerCount()),
-                Optional.ofNullable(s.getTotalRating()).orElse(0),
-                Optional.ofNullable(s.getReviewCount()).orElse(0),
+                s.getIsOutdoors(),
+                new ShelterResponse.CoolingEquipment(
+                        s.getFanCount(),
+                        s.getAirConditionerCount()
+                ),
+                s.getTotalRating(),
+                s.getReviewCount(),
                 s.getPhotoUrl()
         );
     }
 
-    private static LocalTime toLocalTime(java.sql.Time t) {
-        return t == null ? null : t.toLocalTime();
-    }
-
-    private static String formatHours(LocalTime open, LocalTime close) {
-        DateTimeFormatter f = DateTimeFormatter.ofPattern("HH:mm");
-        if (open == null || close == null) {
-            return "-";
-        }
-        return open.format(f) + "–" + close.format(f);
-    }
-
-    private static String formatDistance(Double meters) {
-        if (meters == null) {
+    // 둘 다 null -> "" (빈 문자열)
+    // open null -> "~HH:mm"
+    // close null -> "HH:mm~"
+    // 둘 다 존재 -> "HH:mm~HH:mm"
+    private String formatHours(LocalTime open, LocalTime close) {
+        if (open == null && close == null) {
             return "";
         }
-        return meters < 1000 ? Math.round(meters) + "m" : String.format("%.1fkm", meters / 1000.0);
+
+        String start = (open != null) ? toHHmm(open) : "";
+        String end = (close != null) ? toHHmm(close) : "";
+
+        return start + "~" + end;
     }
 
-    private static double calcAverage(Integer total, Integer count) {
-        int t = Optional.ofNullable(total).orElse(0);
-        int c = Optional.ofNullable(count).orElse(0);
-        if (c == 0) {
+    private String toHHmm(LocalTime t) {
+        return String.format("%02d:%02d", t.getHour(), t.getMinute());
+    }
+
+    private Double calcAverageRating(Integer totalRating, Integer reviewCount) {
+        if (reviewCount == null || reviewCount == 0 || totalRating == null) {
             return 0.0;
         }
-        return Math.round((t / (double) c) * 10.0) / 10.0;
-    }
 
-    // 평일/주말 시간대로 개점 여부 계산(야간 넘어가는 구간도 처리)
-    private static boolean isOpened(LocalTime wkOpen, LocalTime wkClose,
-                                    LocalTime weOpen, LocalTime weClose,
-                                    LocalDateTime now) {
-        DayOfWeek d = now.getDayOfWeek();
-        boolean weekend = (d == DayOfWeek.SATURDAY || d == DayOfWeek.SUNDAY);
-        LocalTime open = weekend ? weOpen : wkOpen;
-        LocalTime close = weekend ? weClose : wkClose;
-        if (open == null || close == null) {
-            return false;
-        }
-
-        LocalTime t = now.toLocalTime();
-        if (open.equals(close)) {
-            return false; // 휴무로 처리
-        }
-        if (close.isBefore(open)) { // 21:00–02:00 같은 구간
-            return !t.isBefore(open) || !t.isAfter(close);
-        }
-        return !t.isBefore(open) && !t.isAfter(close);
+        return totalRating.doubleValue() / reviewCount;
     }
 }

--- a/src/main/java/com/team19/musuimsa/shelter/util/ShelterDtoUtils.java
+++ b/src/main/java/com/team19/musuimsa/shelter/util/ShelterDtoUtils.java
@@ -1,0 +1,67 @@
+package com.team19.musuimsa.shelter.util;
+
+import com.team19.musuimsa.shelter.domain.Shelter;
+import com.team19.musuimsa.shelter.dto.NearbyShelterResponse;
+import com.team19.musuimsa.shelter.dto.OperatingHoursResponse;
+import com.team19.musuimsa.shelter.dto.ShelterResponse;
+
+import java.time.LocalTime;
+
+public final class ShelterDtoUtils {
+    private ShelterDtoUtils() {
+    }
+
+    public static String formatHours(LocalTime open, LocalTime close) {
+        if (open == null && close == null) {
+            return "";
+        }
+
+        String start = (open != null) ? String.format("%02d:%02d", open.getHour(), open.getMinute()) : "";
+        String end = (close != null) ? String.format("%02d:%02d", close.getHour(), close.getMinute()) : "";
+        return start + "~" + end;
+    }
+
+    public static double average(Integer total, Integer count) {
+        if (total == null || count == null || count == 0) {
+            return 0.0;
+        }
+        return total.doubleValue() / count;
+    }
+
+    public static NearbyShelterResponse toNearbyDto(Shelter s /*, Double distanceOpt */) {
+        return new NearbyShelterResponse(
+                s.getShelterId(),
+                s.getName(),
+                s.getAddress(),
+                s.getLatitude().doubleValue(),
+                s.getLongitude().doubleValue(),
+                s.getIsOutdoors(),
+                new OperatingHoursResponse(
+                        formatHours(s.getWeekdayOpenTime(), s.getWeekdayCloseTime()),
+                        formatHours(s.getWeekendOpenTime(), s.getWeekendCloseTime())
+                ),
+                average(s.getTotalRating(), s.getReviewCount()),
+                s.getPhotoUrl()
+        );
+    }
+
+    public static ShelterResponse toDetailDto(Shelter s) {
+        return new ShelterResponse(
+                s.getShelterId(),
+                s.getName(),
+                s.getAddress(),
+                s.getLatitude().doubleValue(),
+                s.getLongitude().doubleValue(),
+                new OperatingHoursResponse(
+                        formatHours(s.getWeekdayOpenTime(), s.getWeekdayCloseTime()),
+                        formatHours(s.getWeekendOpenTime(), s.getWeekendCloseTime())
+                ),
+                s.getCapacity(),
+                s.getIsOutdoors(),
+                new ShelterResponse.CoolingEquipment(s.getFanCount(), s.getAirConditionerCount()),
+                s.getTotalRating(),
+                s.getReviewCount(),
+                s.getPhotoUrl()
+        );
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 spring.application.name=musuimsa
 spring.profiles.active=dev
 spring.config.import=optional:application-secret.properties
+# ?????_?????
 musuimsa.shelter.api.base-url=https://www.safetydata.go.kr
 musuimsa.shelter.api.path=/V2/api/DSSP-IF-10942
-musuimsa.shelter.api.page-size=500
+musuimsa.shelter.api.page-size=30
 musuimsa.shelter.api.format=json
-musuimsa.shelter.api.timeout-ms=10000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,5 +4,6 @@ spring.config.import=optional:application-secret.properties
 # ?????_?????
 musuimsa.shelter.api.base-url=https://www.safetydata.go.kr
 musuimsa.shelter.api.path=/V2/api/DSSP-IF-10942
-musuimsa.shelter.api.page-size=300
+musuimsa.shelter.api.page-size=500
 musuimsa.shelter.api.format=json
+spring.webflux.codec.max-in-memory-size=10MB

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,5 +4,5 @@ spring.config.import=optional:application-secret.properties
 # ?????_?????
 musuimsa.shelter.api.base-url=https://www.safetydata.go.kr
 musuimsa.shelter.api.path=/V2/api/DSSP-IF-10942
-musuimsa.shelter.api.page-size=30
+musuimsa.shelter.api.page-size=300
 musuimsa.shelter.api.format=json

--- a/src/test/java/com/team19/musuimsa/shleter/controller/ShelterControllerTest.java
+++ b/src/test/java/com/team19/musuimsa/shleter/controller/ShelterControllerTest.java
@@ -1,0 +1,115 @@
+package com.team19.musuimsa.shleter.controller;
+
+import com.team19.musuimsa.shelter.controller.ShelterController;
+import com.team19.musuimsa.shelter.dto.NearbyShelterResponse;
+import com.team19.musuimsa.shelter.dto.OperatingHoursResponse;
+import com.team19.musuimsa.shelter.dto.ShelterResponse;
+import com.team19.musuimsa.shelter.service.ShelterService;
+import jakarta.annotation.Resource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ShelterController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ShelterControllerTest {
+
+    @Resource
+    MockMvc mockMvc;
+
+    @MockitoBean
+    ShelterService shelterService;
+
+    @DisplayName("GET /api/shelters/nearby - 가까운 쉼터 목록 JSON 반환")
+    @Test
+    void getNearby_returnsList() throws Exception {
+        List<NearbyShelterResponse> stub = List.of(
+                new NearbyShelterResponse(
+                        1L, "종로 무더위 쉼터", "서울 종로구 세종대로 175", 37.5665, 126.9780, true,
+                        new OperatingHoursResponse("09:00~18:00", "10:00~16:00"),
+                        4.5, "https://example.com/shelter1.jpg"
+                ),
+                new NearbyShelterResponse(
+                        2L, "을지로 무더위 쉼터", "서울 중구 을지로 45", 37.5651, 126.9895, false,
+                        new OperatingHoursResponse("09:00~18:00", "10:00~16:00"),
+                        3.8, "https://example.com/shelter2.jpg"
+                )
+        );
+        Mockito.when(shelterService.findNearbyShelters(anyDouble(), anyDouble()))
+                .thenReturn(stub);
+
+        mockMvc.perform(get("/api/shelters/nearby")
+                        .param("latitude", "37.5")
+                        .param("longitude", "127.0")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", hasSize(2)))
+                // 첫번째 무더위 쉼터
+                .andExpect(jsonPath("$[0].shelterId", is(1)))
+                .andExpect(jsonPath("$[0].name", is("종로 무더위 쉼터")))
+                .andExpect(jsonPath("$[0].address", is("서울 종로구 세종대로 175")))
+                .andExpect(jsonPath("$[0].latitude", is(37.5665)))
+                .andExpect(jsonPath("$[0].longitude", is(126.9780)))
+                .andExpect(jsonPath("$[0].isOutdoors", is(true)))
+                .andExpect(jsonPath("$[0].operatingHoursResponse.weekday", is("09:00~18:00")))
+                .andExpect(jsonPath("$[0].operatingHoursResponse.weekend", is("10:00~16:00")))
+                .andExpect(jsonPath("$[0].averageRating", is(4.5)))
+                .andExpect(jsonPath("$[0].photoUrl", is("https://example.com/shelter1.jpg")))
+                // 두번째 무더위 쉼터
+                .andExpect(jsonPath("$[1].shelterId", is(2)))
+                .andExpect(jsonPath("$[1].name", is("을지로 무더위 쉼터")))
+                .andExpect(jsonPath("$[1].address", is("서울 중구 을지로 45")))
+                .andExpect(jsonPath("$[1].latitude", is(37.5651)))
+                .andExpect(jsonPath("$[1].longitude", is(126.9895)))
+                .andExpect(jsonPath("$[1].isOutdoors", is(false)))
+                .andExpect(jsonPath("$[1].operatingHoursResponse.weekday", is("09:00~18:00")))
+                .andExpect(jsonPath("$[1].operatingHoursResponse.weekend", is("10:00~16:00")))
+                .andExpect(jsonPath("$[1].averageRating", is(3.8)))
+                .andExpect(jsonPath("$[1].photoUrl", is("https://example.com/shelter2.jpg")));
+    }
+
+    @DisplayName("GET /api/shelters/{shelterId} - 상세 쉼터 JSON 반환")
+    @Test
+    void getDetail_returnsOne() throws Exception {
+        ShelterResponse dto = new ShelterResponse(
+                1L, "종로 무더위쉼터", "서울 종로구 세종대로 175", 37.5665, 126.9780,
+                new OperatingHoursResponse("09:00~18:00", "10:00~16:00"),
+                50, true,
+                new ShelterResponse.CoolingEquipment(3, 1),
+                14, 5, "https://example.com/shelter1.jpg"
+        );
+        Mockito.when(shelterService.getShelter(eq(1L))).thenReturn(dto);
+
+        mockMvc.perform(get("/api/shelters/{shelterId}", 1L)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name", is("종로 무더위쉼터")))
+                .andExpect(jsonPath("$.address", is("서울 종로구 세종대로 175")))
+                .andExpect(jsonPath("$.latitude", is(37.5665)))
+                .andExpect(jsonPath("$.longitude", is(126.9780)))
+                .andExpect(jsonPath("$.operatingHoursResponse.weekday", is("09:00~18:00")))
+                .andExpect(jsonPath("$.operatingHoursResponse.weekend", is("10:00~16:00")))
+                .andExpect(jsonPath("$.capacity", is(50)))
+                .andExpect(jsonPath("$.isOutdoors", is(true)))
+                .andExpect(jsonPath("$.coolingEquipment.fanCount", is(3)))
+                .andExpect(jsonPath("$.coolingEquipment.airConditionerCount", is(1)))
+                .andExpect(jsonPath("$.totalRating", is(14)))
+                .andExpect(jsonPath("$.reviewCount", is(5)))
+                .andExpect(jsonPath("$.photoUrl", is("https://example.com/shelter1.jpg")));
+    }
+}

--- a/src/test/java/com/team19/musuimsa/shleter/service/ShelterImportServiceTest.java
+++ b/src/test/java/com/team19/musuimsa/shleter/service/ShelterImportServiceTest.java
@@ -1,0 +1,125 @@
+package com.team19.musuimsa.shleter.service;
+
+import com.team19.musuimsa.exception.external.ExternalApiException;
+import com.team19.musuimsa.shelter.dto.external.ExternalResponse;
+import com.team19.musuimsa.shelter.dto.external.ExternalShelterItem;
+import com.team19.musuimsa.shelter.repository.ShelterRepository;
+import com.team19.musuimsa.shelter.service.ShelterImportService;
+import com.team19.musuimsa.shelter.service.ShelterOpenApiClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ShelterImportServiceTest {
+
+    @Mock
+    ShelterOpenApiClient client;
+    @Mock
+    ShelterRepository shelterRepository;
+    @InjectMocks
+    ShelterImportService service;
+
+    @DisplayName("importOnce - 두 페이지를 돌아가며 저장된 전체 건수를 합산한다. ")
+    @Test
+    void importOnce_savesAcrossPages_andAccumulatesCount() {
+        ExternalResponse page1 = resp(2, 1, 3, List.of(
+                item(1001L, "A", "서울특별시", bd(37.1), bd(127.1),
+                        10, 1, 2, "0900", "1800", "1000", "1700", "002"),
+                item(1002L, "B", "부산광역시", bd(35.1), bd(129.1),
+                        20, 0, 1, "0830", "2000", null, null, "001")
+        ));
+        ExternalResponse page2 = resp(2, 2, 3, List.of(
+                item(1003L, "C", "대전광역시", bd(36.3), bd(127.4),
+                        30, 2, 0, "900", "2130", "1100", "2300", "002")
+        ));
+
+        when(client.fetchPage(1)).thenReturn(page1);
+        when(client.fetchPage(2)).thenReturn(page2);
+
+        int saved = service.importOnce();
+        assertThat(saved).isEqualTo(3);
+
+        verify(shelterRepository, times(2)).saveAll(anyList());
+
+        verify(client).fetchPage(1);
+        verify(client).fetchPage(2);
+        verifyNoMoreInteractions(client);
+    }
+
+    @DisplayName("importOnce - 응답 body 가 null이면 저장 없이 0을 반환한다. ")
+    @Test
+    void importOnce_returnsZero_whenBodyNull() {
+        ExternalResponse page1 = new ExternalResponse(
+                new ExternalResponse.Header("OK", "00", null),
+                2, 1, 0, null // body = null
+        );
+        when(client.fetchPage(1)).thenReturn(page1);
+
+        int saved = service.importOnce();
+        assertThat(saved).isEqualTo(0);
+
+        verify(shelterRepository).saveAll(Collections.emptyList());
+    }
+
+    @DisplayName("importOnce - 외부 API 예외 발생 시 중단하고 누적 저장 수를 반환한다. ")
+    @Test
+    void importOnce_stopsOnExternalApiException() {
+        ExternalResponse page1 = resp(2, 1, 4, List.of(
+                item(2001L, "X", "주소1", bd(37), bd(127),
+                        5, 0, 0, "0800", "1700", null, null, "001")
+        ));
+
+        // 첫 페이지는 정상, 두 번째에서 예외
+        when(client.fetchPage(1)).thenReturn(page1);
+        when(client.fetchPage(2))
+                .thenThrow(new ExternalApiException(
+                        "GET /DSSP-IF-10942?pageNo=2",
+                        new RuntimeException()
+                ));
+
+        int saved = service.importOnce();
+        assertThat(saved).isEqualTo(1);
+
+        verify(shelterRepository, times(1)).saveAll(any());
+
+    }
+
+    private static BigDecimal bd(double v) {
+        return BigDecimal.valueOf(v);
+    }
+
+    private static ExternalShelterItem item(
+            Long id, String name, String addr, BigDecimal la, BigDecimal lo,
+            Integer capacity, Integer fan, Integer ac,
+            String wkOpen, String wkClose, String weOpen, String weClose,
+            String type
+    ) {
+        return new ExternalShelterItem(
+                id, name, addr, la, lo,
+                capacity, fan, ac,
+                wkOpen, wkClose, weOpen, weClose, type
+        );
+    }
+
+    private static ExternalResponse resp(Integer numOfRows,
+                                         Integer pageNo,
+                                         Integer totalCount,
+                                         List<ExternalShelterItem> body
+    ) {
+        return new ExternalResponse(
+                new ExternalResponse.Header("OK", "00", null),
+                numOfRows, pageNo, totalCount, body
+        );
+    }
+}

--- a/src/test/java/com/team19/musuimsa/shleter/service/ShelterServiceTest.java
+++ b/src/test/java/com/team19/musuimsa/shleter/service/ShelterServiceTest.java
@@ -1,0 +1,161 @@
+package com.team19.musuimsa.shleter.service;
+
+import com.team19.musuimsa.exception.notfound.ShelterNotFoundException;
+import com.team19.musuimsa.shelter.domain.Shelter;
+import com.team19.musuimsa.shelter.dto.NearbyShelterResponse;
+import com.team19.musuimsa.shelter.dto.ShelterResponse;
+import com.team19.musuimsa.shelter.repository.ShelterRepository;
+import com.team19.musuimsa.shelter.service.ShelterService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ShelterServiceTest {
+
+    @Mock
+    ShelterRepository repository;
+    @InjectMocks
+    ShelterService service;
+
+    @Test
+    @DisplayName("findNearbyShelters - 엔티티 리스트를 NearbyShelterResponse로 매핑한다. ")
+    void findNearbyShelters_mapsEntitiesToDtos() {
+        Shelter s1 = Shelter.builder()
+                .shelterId(1L)
+                .name("종로 무더위 쉼터")
+                .address("서울 종로구 세종대로 175")
+                .latitude(BigDecimal.valueOf(37.5665))
+                .longitude(BigDecimal.valueOf(126.9780))
+                .weekdayOpenTime(LocalTime.of(9, 0))
+                .weekdayCloseTime(LocalTime.of(18, 0))
+                .weekendOpenTime(LocalTime.of(10, 0))
+                .weekendCloseTime(LocalTime.of(16, 0))
+                .capacity(50)
+                .isOutdoors(true)
+                .fanCount(3)
+                .airConditionerCount(1)
+                .totalRating(14)
+                .reviewCount(5)
+                .photoUrl("https://example.com/shelter1.jpg")
+                .build();
+
+        Shelter s2 = Shelter.builder()
+                .shelterId(2L)
+                .name("을지로 무더위 쉼터")
+                .address("서울 중구 을지로 45")
+                .latitude(BigDecimal.valueOf(37.5651))
+                .longitude(BigDecimal.valueOf(126.9895))
+                .weekdayOpenTime(LocalTime.of(9, 0))
+                .weekdayCloseTime(LocalTime.of(18, 0))
+                .weekendOpenTime(LocalTime.of(10, 0))
+                .weekendCloseTime(LocalTime.of(16, 0))
+                .capacity(100)
+                .isOutdoors(false)
+                .fanCount(2)
+                .airConditionerCount(1)
+                .totalRating(19)
+                .reviewCount(5)
+                .photoUrl("https://example.com/shelter2.jpg")
+                .build();
+
+        when(repository.findNearbyShelters(37.5665, 126.9780, 1000)).thenReturn(List.of(s1, s2));
+
+        List<NearbyShelterResponse> list = service.findNearbyShelters(37.5665, 126.9780);
+
+        assertThat(list).hasSize(2);
+
+        NearbyShelterResponse dto1 = list.get(0);
+        assertSoftly(softly -> {
+            assertThat(dto1.shelterId()).isEqualTo(1L);
+            assertThat(dto1.name()).isEqualTo("종로 무더위 쉼터");
+            assertThat(dto1.address()).isEqualTo("서울 종로구 세종대로 175");
+            assertThat(dto1.latitude()).isEqualTo(37.5665);
+            assertThat(dto1.longitude()).isEqualTo(126.9780);
+            assertThat(dto1.operatingHoursResponse().weekday()).isEqualTo("09:00~18:00");
+            assertThat(dto1.operatingHoursResponse().weekend()).isEqualTo("10:00~16:00");
+            assertThat(dto1.isOutdoors()).isEqualTo(true);
+            assertThat(dto1.averageRating()).isEqualTo(2.8); // 14/5
+            assertThat(dto1.photoUrl()).isEqualTo("https://example.com/shelter1.jpg");
+        });
+
+        NearbyShelterResponse dto2 = list.get(1);
+        assertSoftly(softly -> {
+            assertThat(dto2.shelterId()).isEqualTo(2L);
+            assertThat(dto2.name()).isEqualTo("을지로 무더위 쉼터");
+            assertThat(dto2.address()).isEqualTo("서울 중구 을지로 45");
+            assertThat(dto2.latitude()).isEqualTo(37.5651);
+            assertThat(dto2.longitude()).isEqualTo(126.9895);
+            assertThat(dto2.operatingHoursResponse().weekday()).isEqualTo("09:00~18:00");
+            assertThat(dto2.operatingHoursResponse().weekend()).isEqualTo("10:00~16:00");
+            assertThat(dto2.isOutdoors()).isEqualTo(false);
+            assertThat(dto2.averageRating()).isEqualTo(3.8); // 19/5
+            assertThat(dto2.photoUrl()).isEqualTo("https://example.com/shelter2.jpg");
+        });
+    }
+
+    @DisplayName("getShelter - 존재하지 않으면 ShelterNotFoundException이 발생한다. ")
+    @Test
+    void getShelter_throws_whenNotFound() {
+        when(repository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getShelter(99L))
+                .isInstanceOf(ShelterNotFoundException.class);
+    }
+
+    @DisplayName("getShelter - 존재하면 ShelterResponse로 매핑된다. ")
+    @Test
+    void getShelter_returnsDetailDto() {
+        Shelter s = Shelter.builder()
+                .shelterId(1L)
+                .name("종로 무더위 쉼터")
+                .address("서울 종로구 세종대로 175")
+                .latitude(BigDecimal.valueOf(37.5665))
+                .longitude(BigDecimal.valueOf(126.9780))
+                .weekdayOpenTime(LocalTime.of(9, 0))
+                .weekdayCloseTime(LocalTime.of(18, 0))
+                .weekendOpenTime(LocalTime.of(10, 0))
+                .weekendCloseTime(LocalTime.of(16, 0))
+                .capacity(50)
+                .isOutdoors(true)
+                .fanCount(3)
+                .airConditionerCount(1)
+                .totalRating(14)
+                .reviewCount(5)
+                .photoUrl("https://example.com/shelter1.jpg")
+                .build();
+
+        when(repository.findById(1L)).thenReturn(Optional.of(s));
+
+        ShelterResponse dto = service.getShelter(1L);
+        assertSoftly(softly -> {
+            assertThat(dto.shelterId()).isEqualTo(1L);
+            assertThat(dto.name()).isEqualTo("종로 무더위 쉼터");
+            assertThat(dto.address()).isEqualTo("서울 종로구 세종대로 175");
+            assertThat(dto.latitude()).isEqualTo(37.5665);
+            assertThat(dto.longitude()).isEqualTo(126.9780);
+            assertThat(dto.operatingHoursResponse().weekday()).isEqualTo("09:00~18:00");
+            assertThat(dto.operatingHoursResponse().weekend()).isEqualTo("10:00~16:00");
+            assertThat(dto.capacity()).isEqualTo(50);
+            assertThat(dto.isOutdoors()).isEqualTo(true);
+            assertThat(dto.coolingEquipment().fanCount()).isEqualTo(3);
+            assertThat(dto.coolingEquipment().airConditionerCount()).isEqualTo(1);
+            assertThat(dto.totalRating()).isEqualTo(14);
+            assertThat(dto.reviewCount()).isEqualTo(5);
+            assertThat(dto.photoUrl()).isEqualTo("https://example.com/shelter1.jpg");
+        });
+    }
+}

--- a/src/test/java/com/team19/musuimsa/shleter/util/ShelterDtoUtilsTest.java
+++ b/src/test/java/com/team19/musuimsa/shleter/util/ShelterDtoUtilsTest.java
@@ -1,0 +1,58 @@
+package com.team19.musuimsa.shleter.util;
+
+import com.team19.musuimsa.shelter.util.ShelterDtoUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+class ShelterDtoUtilsTest {
+
+    @DisplayName("formatHours - 둘 다 null이면 빈 문자열이 반환된다. ")
+    @Test
+    void returnsEmpty_whenBothNull() {
+        assertThat(ShelterDtoUtils.formatHours(null, null))
+                .isEqualTo("");
+    }
+
+    @DisplayName("formatHours - open null이면 '~HH:mm' 형태로 반환된다. ")
+    @Test
+    void returnsOnlyEnd_whenOpenNull() {
+        assertThat(ShelterDtoUtils.formatHours(null, LocalTime.of(18, 0)))
+                .isEqualTo("~18:00");
+    }
+
+    @DisplayName("formatHours - close null이면 'HH:mm~' 형태로 반환된다. ")
+    @Test
+    void returnsOnlyStart_whenCloseNull() {
+        assertThat(ShelterDtoUtils.formatHours(LocalTime.of(9, 0), null))
+                .isEqualTo("09:00~");
+    }
+
+    @DisplayName("formatHours - 둘 다 있으면 'HH:mm~HH:mm' 형태로 반환된다. ")
+    @Test
+    void returnsRange_whenBothPresent() {
+        assertThat(ShelterDtoUtils.formatHours(LocalTime.of(9, 0), LocalTime.of(18, 0)))
+                .isEqualTo("09:00~18:00");
+    }
+
+    @DisplayName("average - total 또는 count가 null/0이면 0.0이 반환된다. ")
+    @Test
+    void average_returnsZero_onInvalidInputs() {
+        assertSoftly(softly -> {
+            assertThat(ShelterDtoUtils.average(null, 1)).isEqualTo(0.0);
+            assertThat(ShelterDtoUtils.average(10, null)).isEqualTo(0.0);
+            assertThat(ShelterDtoUtils.average(10, 0)).isEqualTo(0.0);
+        });
+    }
+
+    @DisplayName("average - 올바른 값이면 평균값이 반환된다. ")
+    @Test
+    void average_returnsQuotient() {
+        assertThat(ShelterDtoUtils.average(9, 2))
+                .isEqualTo(4.5);
+    }
+}


### PR DESCRIPTION
### ✅ 멘토님 피드백
**1. 코드 리팩토링**
- `ShelterDtoUtils`: 계산 로직을 전용 클래스로 분리하여 책임 분리
- 중복 로직 일부 정리 및 공통화

**2. 테스트 코드 추가**
- `ShelterServiceTest`
- `ShelterImportServiceTest`
- `ShelterControllerTest`
- `ShelterDtoUtilsTest`

**3. shelterId 충돌 가능성에 대하여**
- 현재 행정안전부(Open API)에서 내려주는 쉼터 ID를 그대로 PK로 사용
- 우려 사항
    - 여러 데이터 출처 사용 시 동일한 ID가 존재할 가능성
    - 추후 사용자가 직접 쉼터 등록 기능이 추가되면 ID 충돌 발생 가능
- 결론
    - 일단 원래 있던 기능 모두 구현하는 것에 집중하기로. 나중에 시간이 나면 확장 여부 논의 예정

### ✅ 멘토님 피드백 받는 동안 추가로 작업한 내용
- 외부 API 응답값 형태에 따른 불필요한 로직 제거 및 가독성 개선
    - 외부 API 칼럼 순서와 동일하게 domain, dto 칼럼 순서 재정렬
    - 화면 구현 시 불필요한 칼럼 제거
    - `OperatingHoursResponse`: Map -> Dto 형태로 변환
 - `@JsonIgnoreProperties` 추가하여 불필요한 필드 무시
 - `@JsonProperty` 매핑 적용
 - `favicon.ico` 추가하여 프론트 관련 에러 로그 제거
 - 가까운 쉼터 반경(radius) 로직 `controller` -> `service`로 이동