### PR TITLE
[Week6] Shelter 멘토님 피드백 반영

### DIFF
--- a/src/main/java/com/team19/musuimsa/config/RestClientConfig.java
+++ b/src/main/java/com/team19/musuimsa/config/RestClientConfig.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestClient;
 
 @Configuration
-public class WebClientConfig {
+public class RestClientConfig {
 
     @Bean
     public RestClient restClient(RestClient.Builder builder) {

--- a/src/main/java/com/team19/musuimsa/config/WebClientConfig.java
+++ b/src/main/java/com/team19/musuimsa/config/WebClientConfig.java
@@ -2,18 +2,13 @@ package com.team19.musuimsa.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.reactive.function.client.ExchangeStrategies;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.client.RestClient;
 
 @Configuration
 public class WebClientConfig {
 
     @Bean
-    public WebClient webClient(WebClient.Builder builder) {
-        return builder
-                .exchangeStrategies(ExchangeStrategies.builder()
-                        .codecs(c -> c.defaultCodecs().maxInMemorySize(10 * 1024 * 1024))
-                        .build())
-                .build();
+    public RestClient restClient(RestClient.Builder builder) {
+        return builder.build();
     }
 }

--- a/src/main/java/com/team19/musuimsa/exception/external/ExternalApiException.java
+++ b/src/main/java/com/team19/musuimsa/exception/external/ExternalApiException.java
@@ -3,8 +3,8 @@ package com.team19.musuimsa.exception.external;
 public class ExternalApiException extends RuntimeException {
     private final String url;
 
-    public ExternalApiException(String url, Throwable cause) {
-        super("외부 API 호출 실패: " + url, cause);
+    public ExternalApiException(String url) {
+        super("외부 API 호출 실패: " + url);
         this.url = url;
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,6 @@ spring.config.import=optional:application-secret.properties
 # ?????_?????
 musuimsa.shelter.api.base-url=https://www.safetydata.go.kr
 musuimsa.shelter.api.path=/V2/api/DSSP-IF-10942
-musuimsa.shelter.api.page-size=500
+musuimsa.shelter.api.page-size=1000
 musuimsa.shelter.api.format=json
 spring.webflux.codec.max-in-memory-size=10MB

--- a/src/test/java/com/team19/musuimsa/shelter/controller/ShelterControllerTest.java
+++ b/src/test/java/com/team19/musuimsa/shelter/controller/ShelterControllerTest.java
@@ -1,6 +1,5 @@
-package com.team19.musuimsa.shleter.controller;
+package com.team19.musuimsa.shelter.controller;
 
-import com.team19.musuimsa.shelter.controller.ShelterController;
 import com.team19.musuimsa.shelter.dto.NearbyShelterResponse;
 import com.team19.musuimsa.shelter.dto.OperatingHoursResponse;
 import com.team19.musuimsa.shelter.dto.ShelterResponse;

--- a/src/test/java/com/team19/musuimsa/shelter/service/ShelterImportServiceTest.java
+++ b/src/test/java/com/team19/musuimsa/shelter/service/ShelterImportServiceTest.java
@@ -80,11 +80,7 @@ class ShelterImportServiceTest {
 
         // 첫 페이지는 정상, 두 번째에서 예외
         when(client.fetchPage(1)).thenReturn(page1);
-        when(client.fetchPage(2))
-                .thenThrow(new ExternalApiException(
-                        "GET /DSSP-IF-10942?pageNo=2",
-                        new RuntimeException()
-                ));
+        when(client.fetchPage(2)).thenThrow(new ExternalApiException("GET /DSSP-IF-10942?pageNo=2"));
 
         int saved = service.importOnce();
         assertThat(saved).isEqualTo(1);

--- a/src/test/java/com/team19/musuimsa/shelter/service/ShelterImportServiceTest.java
+++ b/src/test/java/com/team19/musuimsa/shelter/service/ShelterImportServiceTest.java
@@ -1,11 +1,9 @@
-package com.team19.musuimsa.shleter.service;
+package com.team19.musuimsa.shelter.service;
 
 import com.team19.musuimsa.exception.external.ExternalApiException;
 import com.team19.musuimsa.shelter.dto.external.ExternalResponse;
 import com.team19.musuimsa.shelter.dto.external.ExternalShelterItem;
 import com.team19.musuimsa.shelter.repository.ShelterRepository;
-import com.team19.musuimsa.shelter.service.ShelterImportService;
-import com.team19.musuimsa.shelter.service.ShelterOpenApiClient;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/com/team19/musuimsa/shelter/service/ShelterServiceTest.java
+++ b/src/test/java/com/team19/musuimsa/shelter/service/ShelterServiceTest.java
@@ -1,11 +1,10 @@
-package com.team19.musuimsa.shleter.service;
+package com.team19.musuimsa.shelter.service;
 
 import com.team19.musuimsa.exception.notfound.ShelterNotFoundException;
 import com.team19.musuimsa.shelter.domain.Shelter;
 import com.team19.musuimsa.shelter.dto.NearbyShelterResponse;
 import com.team19.musuimsa.shelter.dto.ShelterResponse;
 import com.team19.musuimsa.shelter.repository.ShelterRepository;
-import com.team19.musuimsa.shelter.service.ShelterService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/com/team19/musuimsa/shelter/util/ShelterDtoUtilsTest.java
+++ b/src/test/java/com/team19/musuimsa/shelter/util/ShelterDtoUtilsTest.java
@@ -1,7 +1,6 @@
-package com.team19.musuimsa.shleter.util;
+package com.team19.musuimsa.shelter.util;
 
 import com.team19.musuimsa.shelter.domain.Shelter;
-import com.team19.musuimsa.shelter.util.ShelterDtoUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
### ✅ 멘토님 피드백 #14 
- 테스트 패키지명 오타 수정(`shleter` -> `shelter`)
- **WebClient(block)** -> **RestClient**로 전환하여 동기 흐름 단순화
- `toShelter()`가 `Optional`이 아닌 **Shelter**를 직접 반환하도록 변경
- **Review** - **Shelter** 연관관계 유지 [(참고)](https://github.com/kakao-tech-campus-3rd-step3/Team19_BE/pull/14#discussion_r2347344385)