### PR TITLE
[Week6] Shelter 멘토님 피드백 반영 추가

### DIFF
--- a/src/main/java/com/team19/musuimsa/exception/conflict/OptimisticLockConflictException.java
+++ b/src/main/java/com/team19/musuimsa/exception/conflict/OptimisticLockConflictException.java
@@ -1,0 +1,7 @@
+package com.team19.musuimsa.exception.conflict;
+
+public class OptimisticLockConflictException extends DataConflictException {
+    public OptimisticLockConflictException() {
+        super("잠시 후 다시 시도해 주세요.");
+    }
+}

--- a/src/main/java/com/team19/musuimsa/review/service/ReviewService.java
+++ b/src/main/java/com/team19/musuimsa/review/service/ReviewService.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 @Transactional
 public class ReviewService {
 
-    private static final int RETRY = 3;
+    private static final int MAX_RETRY = 3;
 
     private final ReviewRepository reviewRepository;
     private final ShelterRepository shelterRepository;
@@ -127,12 +127,12 @@ public class ReviewService {
     }
 
     private void refreshShelterStatsWithRetry(Shelter shelter) {
-        for (int i = 0; i < RETRY; i++) {
+        for (int i = 0; i < MAX_RETRY; i++) {
             try {
                 updateReviewsOfShelter(shelter);
                 return;
             } catch (OptimisticLockingFailureException e) {
-                if (i == RETRY - 1) {
+                if (i == MAX_RETRY - 1) {
                     throw new OptimisticLockConflictException();
                 }
 

--- a/src/main/java/com/team19/musuimsa/shelter/domain/Shelter.java
+++ b/src/main/java/com/team19/musuimsa/shelter/domain/Shelter.java
@@ -1,16 +1,10 @@
 package com.team19.musuimsa.shelter.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.*;
+
 import java.math.BigDecimal;
 import java.time.LocalTime;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -70,6 +64,9 @@ public class Shelter {
 
     @Column(length = 255)
     private String photoUrl;
+
+    @Version
+    private Long version;
 
     public void updateTotalRating(Integer totalRating) {
         this.totalRating = totalRating;

--- a/src/main/java/com/team19/musuimsa/shelter/domain/Shelter.java
+++ b/src/main/java/com/team19/musuimsa/shelter/domain/Shelter.java
@@ -1,7 +1,15 @@
 package com.team19.musuimsa.shelter.domain;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalTime;

--- a/src/test/java/com/team19/musuimsa/review/Repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/team19/musuimsa/review/Repository/ReviewRepositoryTest.java
@@ -1,8 +1,6 @@
 package com.team19.musuimsa.review.Repository;
 
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-
 import com.team19.musuimsa.review.domain.Review;
 import com.team19.musuimsa.review.dto.CreateReviewRequest;
 import com.team19.musuimsa.review.repository.ReviewRepository;
@@ -10,12 +8,15 @@ import com.team19.musuimsa.shelter.domain.Shelter;
 import com.team19.musuimsa.shelter.repository.ShelterRepository;
 import com.team19.musuimsa.user.domain.User;
 import com.team19.musuimsa.user.repository.UserRepository;
-import java.math.BigDecimal;
-import java.time.LocalTime;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @DataJpaTest
 @EnableJpaAuditing
@@ -36,9 +37,23 @@ public class ReviewRepositoryTest {
         User user = new User("aran@email.com", "1234", "윤", "image.url");
         userRepository.save(user);
 
-        Shelter shelter = new Shelter(1000L, "임시 쉼터", "address", BigDecimal.TEN,
-                BigDecimal.TWO, LocalTime.MAX, LocalTime.NOON, LocalTime.MIDNIGHT, LocalTime.MIN, 5,
-                true, 1, 2, 3, 4, "photo.url");
+        Shelter shelter = Shelter.builder()
+                .shelterId(1000L)
+                .name("임시 쉼터")
+                .address("address")
+                .latitude(BigDecimal.TEN)
+                .longitude(BigDecimal.TWO)
+                .weekdayOpenTime(LocalTime.MAX)
+                .weekdayCloseTime(LocalTime.MIDNIGHT)
+                .weekendOpenTime(LocalTime.MIN)
+                .capacity(5)
+                .isOutdoors(true)
+                .fanCount(1)
+                .airConditionerCount(2)
+                .totalRating(3)
+                .reviewCount(4)
+                .photoUrl("photo.url")
+                .build();
 
         shelterRepository.save(shelter);
 

--- a/src/test/java/com/team19/musuimsa/review/domain/ReviewTest.java
+++ b/src/test/java/com/team19/musuimsa/review/domain/ReviewTest.java
@@ -1,14 +1,9 @@
 package com.team19.musuimsa.review.domain;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-
 import com.team19.musuimsa.review.dto.CreateReviewRequest;
 import com.team19.musuimsa.shelter.domain.Shelter;
 import com.team19.musuimsa.user.domain.User;
 import com.team19.musuimsa.user.repository.UserRepository;
-import java.math.BigDecimal;
-import java.time.LocalTime;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +13,12 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @Transactional
 @SpringBootTest
@@ -31,9 +32,24 @@ public class ReviewTest {
 
     @BeforeEach
     void setup() {
-        shelter = new Shelter(10L, "무더위쉼터", "충대정문앞", BigDecimal.TEN, BigDecimal.TWO, LocalTime.MAX,
-                LocalTime.MIDNIGHT, LocalTime.MIN, LocalTime.NOON, 50, false, 10, 3, 4, 5,
-                "photo.url");
+        shelter = Shelter.builder()
+                .shelterId(10L)
+                .name("무더위쉼터")
+                .address("충대정문앞")
+                .latitude(BigDecimal.TEN)
+                .longitude(BigDecimal.TWO)
+                .weekdayOpenTime(LocalTime.MAX)
+                .weekdayCloseTime(LocalTime.MIDNIGHT)
+                .weekendOpenTime(LocalTime.MIN)
+                .weekendCloseTime(LocalTime.NOON)
+                .capacity(50)
+                .isOutdoors(false)
+                .fanCount(10)
+                .airConditionerCount(3)
+                .totalRating(4)
+                .reviewCount(5)
+                .photoUrl("photo.url")
+                .build();
 
         user = userRepository.save(new User("aran@email.com", "1234", "별명", "프사.url"));
 


### PR DESCRIPTION
### ✅ 멘토님 피드백 추가 반영 [(참고)](https://github.com/kakao-tech-campus-3rd-step3/Team19_BE/pull/14#discussion_r2350473176) → **동시성 제어: `@Version` + 낙관적 락**

- **배경**
    - 쉼터 리뷰 생성/수정/삭제 시 `totalRating`, `reviewCount` 값 경쟁 상태에 있음
    - 동시에 여러 요청이 들어오면 마지막 저장이 이전 값을 덮어써 데이터 불일치가 발생 가능성 존재

- **해결 방법**: `@Version` + JPA 낙관적 락 도입
    **=> 낙관적락을 선택한 이유?** 
    현재 상황에서는 리뷰 조회 비중이 높고 쓰기(생성/수정/삭제)는 상대적으로 적을 것으로 예상 → 충돌 빈도가 낮을 때는 낙관적 락이 획득 비용 없이 높은 처리량을 제공하기 때문에 더 효율적인 방법이라 판단

- **주요 변경 사항**
    - Shelter 엔티티에 **@Version Long version** 추가 → Hibernate가 버전 컬럼을 관리하여 동시 수정 충돌 감지
    - 집계 저장 로직 개선
        - `ReviewService.refreshShelterStatsWithRetry()` 추가
        - `saveAndFlush` 시 **OptimisticLockingFailureException** 발생하면 지수배만큼 백오프(20ms, 40ms, 80ms) 로 최대 3회 재시도
        - 재시도 전 최신 Shelter 재조회하여 일관성 유지
    - 예외 매핑: 재시도 한계를 넘으면 `OptimisticLockConflictException(커스텀 예외 추가)`으로 변환해 “잠시 후 다시 시도해 주세요.” 메시지 노출
    - 서비스 메서드 정리: 리뷰 생성/수정/삭제 후 항상 `refreshShelterStatsWithRetry` 호출
    - 테스트 추가 및 수정
        - 낙관적 락 충돌 시 재시도 후 성공,  3회 모두 충돌 시 실패 케이스 추가
        - JPA가 Version을 알아서 관리하도록 하기 위해 Shelter 직접 생성 -> builder 패턴으로 변경