### PR TITLE
[Shelter] 쉼터 사진 저장 구현

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -37,6 +37,10 @@ jobs:
           # dummy-for-ci
           JWT_SECRET_KEY: "dGhpcy1pcy1hLWR1bW15LWtleS1mb3ItY2ktYnVpbGQtb25seS1hbmQtbm90LXJlYWwK"
           MUSUIMSA_SHELTER_API_SERVICE_KEY: "dummy-key-for-ci"
+          MAPILLARY_ACCESS_TOKEN: "dummy-mapillary-token-for-ci"
+          WEATHER_SERVICE_KEY: "dummy-weather-key-for-ci"
+          AWS_CREDENTIALS_ACCESS_KEY: "dummy-aws-access-key-for-ci"
+          AWS_CREDENTIALS_SECRET_KEY: "dummy-aws-secret-key-for-ci"
         run: ./gradlew build # 프로젝트를 빌드합니다. 이 과정에서 테스트도 자동으로 함께 실행됩니다.
 
   deploy:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -102,6 +102,10 @@ jobs:
               -e SPRING_PROFILES_ACTIVE=prod \
               -e jwt.secret.key=${{ secrets.JWT_SECRET_KEY }} \
               -e musuimsa.shelter.api.service-key=${{ secrets.MUSUIMSA_SHELTER_API_SERVICE_KEY }} \
+              -e mapillary.access-token=${{ secrets.MAPILLARY_ACCESS_TOKEN }} \
+              -e weather.service-key=${{ secrets.WEATHER_SERVICE_KEY }} \
+              -e aws.credentials.access-key=${{ secrets.AWS_CREDENTIALS_ACCESS_KEY }} \
+              -e aws.credentials.secret-key=${{ secrets.AWS_CREDENTIALS_SECRET_KEY }} \
               -e spring.datasource.url=${{ secrets.DB_URL }} \
               -e spring.datasource.username=${{ secrets.DB_USERNAME }} \
               -e spring.datasource.password=${{ secrets.DB_PASSWORD }} \

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -41,8 +41,6 @@ jobs:
           WEATHER_SERVICE_KEY: "dummy-weather-key-for-ci"
           AWS_CREDENTIALS_ACCESS_KEY: "dummy-aws-access-key-for-ci"
           AWS_CREDENTIALS_SECRET_KEY: "dummy-aws-secret-key-for-ci"
-          AWS_REGION: "ap-northeast-2"
-          AWS_S3_ENDPOINT: "http://localhost:9090" # S3Mock을 위한 endpoint
         run: ./gradlew build # 프로젝트를 빌드합니다. 이 과정에서 테스트도 자동으로 함께 실행됩니다.
 
   deploy:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -41,6 +41,8 @@ jobs:
           WEATHER_SERVICE_KEY: "dummy-weather-key-for-ci"
           AWS_CREDENTIALS_ACCESS_KEY: "dummy-aws-access-key-for-ci"
           AWS_CREDENTIALS_SECRET_KEY: "dummy-aws-secret-key-for-ci"
+          AWS_REGION: "ap-northeast-2"
+          AWS_S3_ENDPOINT: "http://localhost:9090" # S3Mock을 위한 endpoint
         run: ./gradlew build # 프로젝트를 빌드합니다. 이 과정에서 테스트도 자동으로 함께 실행됩니다.
 
   deploy:

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ dependencies {
     // Sprig Batch
     implementation 'org.springframework.boot:spring-boot-starter-batch'
 
+    // AWS SDK v2 (S3)
+    implementation platform("software.amazon.awssdk:bom:2.25.61")
+    implementation "software.amazon.awssdk:s3"
+
     // Lombok
     compileOnly 'org.projectlombok:lombok'
 

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,15 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.batch:spring-batch-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Mapillary mock
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+
+    // S3Mock
+    testImplementation("com.adobe.testing:s3mock-junit5:3.8.0")
+
+    // H2 (테스트 DB)
+    testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/team19/musuimsa/batch/ShelterUpdateJobListener.java
+++ b/src/main/java/com/team19/musuimsa/batch/ShelterUpdateJobListener.java
@@ -39,23 +39,25 @@ public class ShelterUpdateJobListener implements JobExecutionListener {
     @Override
     public void afterJob(JobExecution jobExecution) {
         ExecutionContext ctx = jobExecution.getExecutionContext();
-        Set<Long> updatedIds = (Set<Long>) ctx.get(ShelterImportBatchConfig.UPDATED_IDS_KEY);
+        Set<Long> updatedIds = (Set<Long>) ctx.get(ShelterImportBatchConfig.LOCATION_UPDATED_IDS_KEY);
 
-        if (updatedIds.isEmpty()) {
+        if (updatedIds == null || updatedIds.isEmpty()) {
             log.info("<<<< Shelter Update Job END (변경된 쉼터 없음, 사진 갱신 생략)");
             return;
         }
 
         int processed = 0, updated = 0, failed = 0;
-        for (Long id : updatedIds) {
-            processed++;
-            try {
-                if (shelterPhotoService.updatePhoto(id)) {
-                    updated++;
+        if (updatedIds != null) {
+            processed = updatedIds.size();
+            for (Long id : updatedIds) {
+                try {
+                    if (shelterPhotoService.updatePhoto(id)) {
+                        updated++;
+                    }
+                } catch (Exception e) {
+                    failed++;
+                    log.warn("Photo update failed for shelter {}", id, e);
                 }
-            } catch (Exception e) {
-                failed++;
-                log.warn("photo update failed. shelterId={}", id, e);
             }
         }
 

--- a/src/main/java/com/team19/musuimsa/batch/ShelterUpdateJobListener.java
+++ b/src/main/java/com/team19/musuimsa/batch/ShelterUpdateJobListener.java
@@ -46,7 +46,10 @@ public class ShelterUpdateJobListener implements JobExecutionListener {
             return;
         }
 
-        int processed = 0, updated = 0, failed = 0;
+        int processed = 0;
+        int updated = 0;
+        int failed = 0;
+
         if (updatedIds != null) {
             processed = updatedIds.size();
             for (Long id : updatedIds) {

--- a/src/main/java/com/team19/musuimsa/config/MapillaryRestClientConfig.java
+++ b/src/main/java/com/team19/musuimsa/config/MapillaryRestClientConfig.java
@@ -1,0 +1,31 @@
+package com.team19.musuimsa.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class MapillaryRestClientConfig {
+
+    @Bean(name = "mapillaryRestClient")
+    public RestClient mapillaryRestClient(
+            RestClient.Builder builder,
+            @Value("${mapillary.api-base}") String apiBase,
+            @Value("${mapillary.access-token}") String accessToken,
+            @Value("${mapillary.connect-timeout-ms}") int connectTimeoutMs,
+            @Value("${mapillary.read-timeout-ms}") int readTimeoutMs
+    ) {
+        SimpleClientHttpRequestFactory rf = new SimpleClientHttpRequestFactory();
+        rf.setConnectTimeout(connectTimeoutMs);
+        rf.setReadTimeout(readTimeoutMs);
+
+        return builder
+                .requestFactory(rf)
+                .baseUrl(apiBase)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "OAuth " + accessToken)
+                .build();
+    }
+}

--- a/src/main/java/com/team19/musuimsa/config/S3Config.java
+++ b/src/main/java/com/team19/musuimsa/config/S3Config.java
@@ -1,0 +1,33 @@
+package com.team19.musuimsa.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+
+@Configuration
+public class S3Config {
+
+    @Bean
+    public S3Client s3Client(
+            @Value("${aws.s3.region}") String region,
+            @Value("${aws.credentials.access-key:}") String accessKey,
+            @Value("${aws.credentials.secret-key:}") String secretKey
+    ) {
+        AwsCredentialsProvider provider = (!accessKey.isBlank() && !secretKey.isBlank())
+                ? StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey))
+                : DefaultCredentialsProvider.create();
+
+        S3ClientBuilder builder = S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(provider);
+
+        return builder.build();
+    }
+}

--- a/src/main/java/com/team19/musuimsa/mapillary/MapillaryPhotoAgent.java
+++ b/src/main/java/com/team19/musuimsa/mapillary/MapillaryPhotoAgent.java
@@ -1,0 +1,138 @@
+package com.team19.musuimsa.mapillary;
+
+import com.team19.musuimsa.mapillary.dto.MapillaryImageResponse;
+import com.team19.musuimsa.mapillary.dto.MapillaryImagesResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.math.BigDecimal;
+import java.util.Comparator;
+import java.util.Locale;
+import java.util.Optional;
+
+@Component
+public class MapillaryPhotoAgent {
+
+    private static final Logger log = LoggerFactory.getLogger(MapillaryPhotoAgent.class);
+
+    private final RestClient mapillary;
+    private final S3Client s3Client;
+    private final String bucket;
+    private final String baseUrl;
+    private final String folder;
+    private final int searchLimit;
+
+    public MapillaryPhotoAgent(
+            @Qualifier("mapillaryRestClient") RestClient mapillary,
+            S3Client s3Client,
+            @Value("${aws.s3.bucket}") String bucket,
+            @Value("${aws.s3.base-url}") String baseUrl,
+            @Value("${aws.s3.folder:shelters}") String folder,
+            @Value("${mapillary.limit}") int searchLimit
+    ) {
+        this.mapillary = mapillary;
+        this.s3Client = s3Client;
+        this.bucket = bucket;
+        this.baseUrl = baseUrl;
+        this.folder = folder;
+        this.searchLimit = searchLimit;
+    }
+
+    // lat/lon 기준 반경(m)에서 가장 가까운 Mapillary 사진을 찾아 S3로 업로드 후 공개 URL 반환
+    public Optional<String> findAndStore(BigDecimal latitude, BigDecimal longitude, int radiusMeters, long shelterId) {
+        // 1) 반경 → BBOX로 변환하여 /images 조회
+        String url = buildImagesUrl(latitude.doubleValue(), longitude.doubleValue(), radiusMeters, searchLimit);
+        MapillaryImagesResponse res = mapillary.get().uri(url).retrieve().body(MapillaryImagesResponse.class);
+
+        int dataSize = res.data() == null ? 0 : res.data().size();
+        log.info("[Mapillary] url={}, dataSize={}", url, dataSize);
+
+        if (res.data() == null || res.data().isEmpty()) {
+            // 1차에 없으면 반경 2배로 한 번 더 시도
+            String url2 = buildImagesUrl(latitude.doubleValue(), longitude.doubleValue(), radiusMeters * 2, searchLimit);
+            res = mapillary.get().uri(url2).retrieve().body(MapillaryImagesResponse.class);
+            int size2 = res.data() == null ? 0 : res.data().size();
+            log.info("[Mapillary] retry url={}, dataSize={}", url2, size2);
+            if (res.data() == null || res.data().isEmpty()) {
+                return Optional.empty();
+            }
+        }
+
+        // 2) 썸네일 있는 것만 남기고 거리 계산해서 가장 가까운 한 장
+        Optional<MapillaryImageResponse> pick = res.data().stream()
+                .filter(i -> i.bestThumbUrl() != null)
+                .min(Comparator.comparingDouble(i -> distanceM(latitude.doubleValue(), longitude.doubleValue(), i.latitude(), i.longitude())));
+
+        if (pick.isEmpty()) {
+            return Optional.empty();
+        }
+
+        String thumbUrl = pick.get().bestThumbUrl();
+
+        // 3) 썸네일 바이트 다운로드
+        ResponseEntity<byte[]> entity = mapillary.get().uri(thumbUrl).retrieve().toEntity(byte[].class);
+        entity.getBody();
+
+        // 4) Content-Type → 확장자 결정 (기본 jpg)
+        entity.getHeaders().getContentType();
+        String contentType = entity.getHeaders().getContentType().toString();
+        String ext = contentType.contains("webp") ? ".webp" : ".jpg";
+
+        // 5) S3 업로드
+        String key = folder + "/" + shelterId + ext;
+        s3Client.putObject(
+                PutObjectRequest.builder()
+                        .bucket(bucket)
+                        .key(key)
+                        .contentType(contentType)
+                        .build(),
+                RequestBody.fromBytes(entity.getBody())
+        );
+
+        String publicUrl = baseUrl + "/" + key;
+        log.info("[Mapillary] uploaded: {}", publicUrl);
+        return Optional.of(publicUrl);
+    }
+
+    private static String buildImagesUrl(double lat, double lon, double radiusMeters, int limit) {
+        double dLat = radiusMeters / 111_000d;
+        double dLon = radiusMeters / (111_000d * Math.cos(Math.toRadians(lat)));
+
+        double minLat = lat - dLat;
+        double maxLat = lat + dLat;
+        double minLon = lon - dLon;
+        double maxLon = lon + dLon;
+
+        String fields = "id,thumb_2048_url,thumb_1024_url,computed_geometry,captured_at";
+        return UriComponentsBuilder.fromPath("/images")
+                .queryParam("bbox", String.format(Locale.US, "%.6f,%.6f,%.6f,%.6f",
+                        minLon, minLat, maxLon, maxLat))
+                .queryParam("limit", limit)
+                .queryParam("fields", fields)
+                .toUriString();
+    }
+
+    private static double distanceM(double lat1, double lon1, Double lat2, Double lon2) {
+        if (lat2 == null || lon2 == null) {
+            return Double.MAX_VALUE;
+        }
+
+        double R = 6371000d;
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+
+        return 2 * R * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    }
+}

--- a/src/main/java/com/team19/musuimsa/mapillary/dto/MapillaryGeometryResponse.java
+++ b/src/main/java/com/team19/musuimsa/mapillary/dto/MapillaryGeometryResponse.java
@@ -1,0 +1,7 @@
+package com.team19.musuimsa.mapillary.dto;
+
+public record MapillaryGeometryResponse(
+        String type,
+        double[] coordinates
+) {
+}

--- a/src/main/java/com/team19/musuimsa/mapillary/dto/MapillaryImageResponse.java
+++ b/src/main/java/com/team19/musuimsa/mapillary/dto/MapillaryImageResponse.java
@@ -1,0 +1,29 @@
+package com.team19.musuimsa.mapillary.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record MapillaryImageResponse(
+        String id,
+        @JsonProperty("thumb_2048_url")
+        String thumb2048Url,
+        @JsonProperty("thumb_1024_url")
+        String thumb1024Url,
+        @JsonProperty("computed_geometry")
+        MapillaryGeometryResponse computedGeometry,
+        @JsonProperty("captured_at")
+        Long capturedAt
+) {
+    public String bestThumbUrl() {
+        return thumb2048Url != null ? thumb2048Url : thumb1024Url;
+    }
+
+    public Double latitude() {
+        return (computedGeometry == null || computedGeometry.coordinates() == null)
+                ? null : computedGeometry.coordinates()[1];
+    }
+
+    public Double longitude() {
+        return (computedGeometry == null || computedGeometry.coordinates() == null)
+                ? null : computedGeometry.coordinates()[0];
+    }
+}

--- a/src/main/java/com/team19/musuimsa/mapillary/dto/MapillaryImagesResponse.java
+++ b/src/main/java/com/team19/musuimsa/mapillary/dto/MapillaryImagesResponse.java
@@ -1,0 +1,6 @@
+package com.team19.musuimsa.mapillary.dto;
+
+import java.util.List;
+
+public record MapillaryImagesResponse(List<MapillaryImageResponse> data) {
+}

--- a/src/main/java/com/team19/musuimsa/shelter/controller/ShelterAdminController.java
+++ b/src/main/java/com/team19/musuimsa/shelter/controller/ShelterAdminController.java
@@ -1,5 +1,6 @@
 package com.team19.musuimsa.shelter.controller;
 
+import com.team19.musuimsa.shelter.dto.ShelterImportResponse;
 import com.team19.musuimsa.shelter.service.ShelterImportService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,8 +16,8 @@ public class ShelterAdminController {
     private final ShelterImportService importService;
 
     @PostMapping("/import")
-    public ResponseEntity<Integer> importShelters() {
+    public ResponseEntity<ShelterImportResponse> importShelters() {
         int saved = importService.importOnce();
-        return ResponseEntity.ok(saved);
+        return ResponseEntity.ok(new ShelterImportResponse(saved));
     }
 }

--- a/src/main/java/com/team19/musuimsa/shelter/controller/ShelterAdminController.java
+++ b/src/main/java/com/team19/musuimsa/shelter/controller/ShelterAdminController.java
@@ -1,12 +1,20 @@
 package com.team19.musuimsa.shelter.controller;
 
+import com.team19.musuimsa.shelter.dto.BatchReport;
+import com.team19.musuimsa.shelter.dto.BatchUpdateResponse;
 import com.team19.musuimsa.shelter.dto.ShelterImportResponse;
+import com.team19.musuimsa.shelter.dto.ShelterPhotoUrlUpdateResponse;
 import com.team19.musuimsa.shelter.service.ShelterImportService;
+import com.team19.musuimsa.shelter.service.ShelterPhotoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/admin/shelters")
@@ -14,10 +22,40 @@ import org.springframework.web.bind.annotation.RestController;
 public class ShelterAdminController {
 
     private final ShelterImportService importService;
+    private final ShelterPhotoService photoService;
 
     @PostMapping("/import")
     public ResponseEntity<ShelterImportResponse> importShelters() {
         int saved = importService.importOnce();
         return ResponseEntity.ok(new ShelterImportResponse(saved));
+    }
+
+
+    // Shelter photoUrl 단건 저장
+    @PostMapping("/photos/{shelterId}")
+    public ResponseEntity<ShelterPhotoUrlUpdateResponse> updateOne(@PathVariable Long shelterId) {
+        Optional<String> urlOpt = photoService.updatePhotoAndReturnUrl(shelterId);
+
+        if (urlOpt.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+
+        return ResponseEntity.ok(new ShelterPhotoUrlUpdateResponse(true, urlOpt.get()));
+    }
+
+    // Shelter photoUrl 모두 저장
+    @PostMapping("/photos/all")
+    public ResponseEntity<BatchUpdateResponse> updateBatch(
+            @RequestParam(defaultValue = "100") int pageSize,
+            @RequestParam(defaultValue = "100") int maxPages
+    ) {
+        BatchReport batchReport = photoService.updateAllMissing(pageSize, maxPages);
+        return ResponseEntity.ok(
+                new BatchUpdateResponse(
+                        batchReport.processed(),
+                        batchReport.updated(),
+                        batchReport.failed()
+                )
+        );
     }
 }

--- a/src/main/java/com/team19/musuimsa/shelter/domain/Shelter.java
+++ b/src/main/java/com/team19/musuimsa/shelter/domain/Shelter.java
@@ -1,21 +1,22 @@
 package com.team19.musuimsa.shelter.domain;
 
-import static com.team19.musuimsa.batch.ShelterImportBatchConfig.parseTime;
-
 import com.team19.musuimsa.shelter.dto.external.ExternalShelterItem;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
-import java.math.BigDecimal;
-import java.time.LocalTime;
-import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+import java.util.Objects;
+
+import static com.team19.musuimsa.batch.ShelterImportBatchConfig.parseTime;
 
 @Entity
 @Getter
@@ -89,6 +90,17 @@ public class Shelter {
         this.reviewCount = reviewCount;
     }
 
+    public boolean updatePhotoUrl(String newPhotoUrl) {
+        if (newPhotoUrl == null || newPhotoUrl.isBlank()) {
+            return false;
+        }
+        if (newPhotoUrl.equals(this.photoUrl)) {
+            return false;
+        }
+        this.photoUrl = newPhotoUrl;
+        return true;
+    }
+
     public static Shelter toShelter(ExternalShelterItem i) {
         return Shelter.builder()
                 .shelterId(i.rstrFcltyNo())
@@ -109,7 +121,7 @@ public class Shelter {
     }
 
     public boolean updateShelterInfo(ExternalShelterItem item, LocalTime weekdayOpen,
-            LocalTime weekdayClose, LocalTime weekendOpen, LocalTime weekendClose) {
+                                     LocalTime weekdayClose, LocalTime weekendOpen, LocalTime weekendClose) {
         boolean isChanged = false;
 
         if (!Objects.equals(this.name, item.rstrNm())) {

--- a/src/main/java/com/team19/musuimsa/shelter/domain/Shelter.java
+++ b/src/main/java/com/team19/musuimsa/shelter/domain/Shelter.java
@@ -1,5 +1,6 @@
 package com.team19.musuimsa.shelter.domain;
 
+import com.team19.musuimsa.shelter.dto.UpdateResultResponse;
 import com.team19.musuimsa.shelter.dto.external.ExternalShelterItem;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -120,9 +121,11 @@ public class Shelter {
                 .build();
     }
 
-    public boolean updateShelterInfo(ExternalShelterItem item, LocalTime weekdayOpen,
-                                     LocalTime weekdayClose, LocalTime weekendOpen, LocalTime weekendClose) {
+    public UpdateResultResponse updateShelterInfo(ExternalShelterItem item,
+                                                  LocalTime weekdayOpen, LocalTime weekdayClose,
+                                                  LocalTime weekendOpen, LocalTime weekendClose) {
         boolean isChanged = false;
+        boolean locationChanged = false;
 
         if (!Objects.equals(this.name, item.rstrNm())) {
             this.name = item.rstrNm();
@@ -135,10 +138,12 @@ public class Shelter {
         if (this.latitude.compareTo(item.la()) != 0) {
             this.latitude = item.la();
             isChanged = true;
+            locationChanged = true; // ← 위/경도 바뀌면 사진 트리거
         }
         if (this.longitude.compareTo(item.lo()) != 0) {
             this.longitude = item.lo();
             isChanged = true;
+            locationChanged = true; // ← 위/경도 바뀌면 사진 트리거
         }
         if (!Objects.equals(this.capacity, item.usePsblNmpr())) {
             this.capacity = item.usePsblNmpr();
@@ -173,6 +178,6 @@ public class Shelter {
             this.isOutdoors = outdoors;
             isChanged = true;
         }
-        return isChanged;
+        return new UpdateResultResponse(isChanged, locationChanged);
     }
 }

--- a/src/main/java/com/team19/musuimsa/shelter/dto/BatchReport.java
+++ b/src/main/java/com/team19/musuimsa/shelter/dto/BatchReport.java
@@ -1,0 +1,8 @@
+package com.team19.musuimsa.shelter.dto;
+
+public record BatchReport(
+        int processed,
+        int updated,
+        int failed
+) {
+}

--- a/src/main/java/com/team19/musuimsa/shelter/dto/BatchUpdateResponse.java
+++ b/src/main/java/com/team19/musuimsa/shelter/dto/BatchUpdateResponse.java
@@ -1,0 +1,8 @@
+package com.team19.musuimsa.shelter.dto;
+
+public record BatchUpdateResponse(
+        int processed,
+        int updated,
+        int failed
+) {
+}

--- a/src/main/java/com/team19/musuimsa/shelter/dto/ShelterImportResponse.java
+++ b/src/main/java/com/team19/musuimsa/shelter/dto/ShelterImportResponse.java
@@ -1,0 +1,6 @@
+package com.team19.musuimsa.shelter.dto;
+
+public record ShelterImportResponse(
+        int saved
+) {
+}

--- a/src/main/java/com/team19/musuimsa/shelter/dto/ShelterPhotoUrlUpdateResponse.java
+++ b/src/main/java/com/team19/musuimsa/shelter/dto/ShelterPhotoUrlUpdateResponse.java
@@ -1,0 +1,7 @@
+package com.team19.musuimsa.shelter.dto;
+
+public record ShelterPhotoUrlUpdateResponse(
+        boolean updated,
+        String photoUrl
+) {
+}

--- a/src/main/java/com/team19/musuimsa/shelter/dto/UpdateResultResponse.java
+++ b/src/main/java/com/team19/musuimsa/shelter/dto/UpdateResultResponse.java
@@ -1,0 +1,7 @@
+package com.team19.musuimsa.shelter.dto;
+
+public record UpdateResultResponse(
+        boolean isChanged, // DB 저장을 위한 변경 여부
+        boolean locationChanged // 사진 갱신 트리거 여부 (위/경도 변경 시)
+) {
+}

--- a/src/main/java/com/team19/musuimsa/shelter/repository/ShelterRepository.java
+++ b/src/main/java/com/team19/musuimsa/shelter/repository/ShelterRepository.java
@@ -1,6 +1,7 @@
 package com.team19.musuimsa.shelter.repository;
 
 import com.team19.musuimsa.shelter.domain.Shelter;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -28,4 +29,14 @@ public interface ShelterRepository extends JpaRepository<Shelter, Long> {
             @Param("lng") double lng,
             @Param("radius") int radius
     );
+
+    @Query("""
+              select s.shelterId
+              from Shelter s
+              where (s.photoUrl is null or s.photoUrl = '')
+                and s.latitude  is not null
+                and s.longitude is not null
+              order by s.shelterId asc
+            """)
+    List<Long> findPendingShelterIds(Pageable pageable);
 }

--- a/src/main/java/com/team19/musuimsa/shelter/service/ShelterPhotoService.java
+++ b/src/main/java/com/team19/musuimsa/shelter/service/ShelterPhotoService.java
@@ -2,6 +2,7 @@ package com.team19.musuimsa.shelter.service;
 
 import com.team19.musuimsa.mapillary.MapillaryPhotoAgent;
 import com.team19.musuimsa.shelter.domain.Shelter;
+import com.team19.musuimsa.shelter.dto.BatchReport;
 import com.team19.musuimsa.shelter.repository.ShelterRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Value;
@@ -44,30 +45,6 @@ public class ShelterPhotoService {
         shelter.updatePhotoUrl(url.get());
         shelterRepository.save(shelter);
         return true;
-    }
-
-    public static class BatchReport {
-        private final int processed;
-        private final int updated;
-        private final int failed;
-
-        public BatchReport(int processed, int updated, int failed) {
-            this.processed = processed;
-            this.updated = updated;
-            this.failed = failed;
-        }
-
-        public int getProcessed() {
-            return processed;
-        }
-
-        public int getUpdated() {
-            return updated;
-        }
-
-        public int getFailed() {
-            return failed;
-        }
     }
 
     // photoUrl이 비어있는 쉼터만 페이징으로 채우기

--- a/src/main/java/com/team19/musuimsa/shelter/service/ShelterPhotoService.java
+++ b/src/main/java/com/team19/musuimsa/shelter/service/ShelterPhotoService.java
@@ -1,0 +1,105 @@
+package com.team19.musuimsa.shelter.service;
+
+import com.team19.musuimsa.mapillary.MapillaryPhotoAgent;
+import com.team19.musuimsa.shelter.domain.Shelter;
+import com.team19.musuimsa.shelter.repository.ShelterRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional
+public class ShelterPhotoService {
+
+    private final ShelterRepository shelterRepository;
+    private final MapillaryPhotoAgent mapillaryPhotoAgent;
+
+    @Value("${mapillary.radius-m}")
+    private int radiusM;
+
+    @Value("${mapillary.batch-throttle-ms}")
+    private int throttleMs;
+
+    public ShelterPhotoService(ShelterRepository shelterRepository, MapillaryPhotoAgent mapillaryPhotoAgent) {
+        this.shelterRepository = shelterRepository;
+        this.mapillaryPhotoAgent = mapillaryPhotoAgent;
+    }
+
+    // Mapillary에서 가장 가까운 사진을 찾아 S3 업로드 후 photoUrl 저장
+    public boolean updatePhoto(Long shelterId) {
+        Shelter shelter = shelterRepository.findById(shelterId).orElse(null);
+        if (shelter == null) {
+            return false;
+        }
+
+        Optional<String> url = mapillaryPhotoAgent.findAndStore(shelter.getLatitude(), shelter.getLongitude(), radiusM, shelter.getShelterId());
+        if (url.isEmpty()) {
+            return false;
+        }
+
+        shelter.updatePhotoUrl(url.get());
+        shelterRepository.save(shelter);
+        return true;
+    }
+
+    public static class BatchReport {
+        private final int processed;
+        private final int updated;
+        private final int failed;
+
+        public BatchReport(int processed, int updated, int failed) {
+            this.processed = processed;
+            this.updated = updated;
+            this.failed = failed;
+        }
+
+        public int getProcessed() {
+            return processed;
+        }
+
+        public int getUpdated() {
+            return updated;
+        }
+
+        public int getFailed() {
+            return failed;
+        }
+    }
+
+    // photoUrl이 비어있는 쉼터만 페이징으로 채우기
+    public BatchReport updateAllMissing(int pageSize, int maxPages) {
+        int processed = 0;
+        int updated = 0;
+        int failed = 0;
+
+        for (int page = 0; page < maxPages; page++) {
+            List<Long> ids = shelterRepository.findPendingShelterIds(PageRequest.of(0, pageSize));
+            if (ids == null || ids.isEmpty()) {
+                break;
+            }
+
+            for (Long id : ids) {
+                processed++;
+                try {
+                    boolean ok = updatePhoto(id);
+                    if (ok) {
+                        updated++;
+                    }
+                } catch (Exception e) {
+                    failed++;
+                }
+                if (throttleMs > 0) {
+                    try {
+                        Thread.sleep(throttleMs);
+                    } catch (InterruptedException ignored) {
+                    }
+                }
+            }
+        }
+        return new BatchReport(processed, updated, failed);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,6 +6,7 @@ musuimsa.shelter.api.base-url=https://www.safetydata.go.kr
 musuimsa.shelter.api.path=/V2/api/DSSP-IF-10942
 musuimsa.shelter.api.page-size=1000
 musuimsa.shelter.api.format=json
+musuimsa.rest-client.timeout-seconds=5
 # aws-s3
 aws.s3.region=ap-northeast-2
 aws.s3.bucket=musuimsa

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,6 +6,15 @@ musuimsa.shelter.api.base-url=https://www.safetydata.go.kr
 musuimsa.shelter.api.path=/V2/api/DSSP-IF-10942
 musuimsa.shelter.api.page-size=1000
 musuimsa.shelter.api.format=json
-spring.webflux.codec.max-in-memory-size=10MB
-spring.batch.job.enabled=false
-musuimsa.rest-client.timeout-seconds=5
+# aws-s3
+aws.s3.region=ap-northeast-2
+aws.s3.bucket=musuimsa
+aws.s3.base-url=https://musuimsa.s3.ap-northeast-2.amazonaws.com
+aws.s3.folder=shelters
+# shelter(photoUrl)_Mapillary
+mapillary.api-base=https://graph.mapillary.com
+mapillary.limit=20
+mapillary.radius-m=150
+mapillary.connect-timeout-ms=4000
+mapillary.read-timeout-ms=6000
+mapillary.batch-throttle-ms=10

--- a/src/test/java/com/team19/musuimsa/shelter/domain/ShelterTest.java
+++ b/src/test/java/com/team19/musuimsa/shelter/domain/ShelterTest.java
@@ -1,191 +1,146 @@
 package com.team19.musuimsa.shelter.domain;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
+import com.team19.musuimsa.shelter.dto.UpdateResultResponse;
 import com.team19.musuimsa.shelter.dto.external.ExternalShelterItem;
-import java.math.BigDecimal;
-import java.time.LocalTime;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("Shelter 엔티티 테스트")
+import java.math.BigDecimal;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 class ShelterTest {
 
-    private Shelter shelter;
-    private final LocalTime baseWeekdayOpen = LocalTime.of(9, 0);
-    private final LocalTime baseWeekdayClose = LocalTime.of(18, 0);
-    private final LocalTime baseWeekendOpen = LocalTime.of(10, 0);
-    private final LocalTime baseWeekendClose = LocalTime.of(17, 0);
+    @Test
+    @DisplayName("photoUrl이 새 값으로 변경되면 true 반환하고 필드가 갱신된다")
+    void updatePhotoUrl_success_whenDifferent() {
+        // given
+        Shelter shelter = newShelter();
 
-    @BeforeEach
-    void setUp() {
-        shelter = Shelter.builder()
+        // when
+        boolean changed = shelter.updatePhotoUrl("https://example.com/after.jpg");
+
+        // then
+        assertThat(changed).isTrue();
+        assertThat(shelter.getPhotoUrl()).isEqualTo("https://example.com/after.jpg");
+    }
+
+    @Test
+    @DisplayName("photoUrl이 동일하면 false 반환하고 값이 유지된다")
+    void updatePhotoUrl_noop_whenSame() {
+        // given
+        Shelter shelter = newShelter();
+
+        // when
+        boolean changed = shelter.updatePhotoUrl("https://example.com/shelter1.jpg");
+
+        // then
+        assertThat(changed).isFalse();
+        assertThat(shelter.getPhotoUrl()).isEqualTo("https://example.com/shelter1.jpg");
+    }
+
+    @Test
+    @DisplayName("photoUrl이 null이면 false 반환하고 변경하지 않는다")
+    void updatePhotoUrl_noop_whenNull() {
+        // given
+        Shelter shelter = newShelter();
+
+        // when
+        boolean changed = shelter.updatePhotoUrl(null);
+
+        // then
+        assertThat(changed).isFalse();
+        assertThat(shelter.getPhotoUrl()).isEqualTo("https://example.com/shelter1.jpg");
+    }
+
+    @Test
+    @DisplayName("photoUrl이 공백이면 false 반환하고 변경하지 않는다")
+    void updatePhotoUrl_noop_whenBlank() {
+        // given
+        Shelter shelter = newShelter();
+
+        // when
+        boolean changed = shelter.updatePhotoUrl("   ");
+
+        // then
+        assertThat(changed).isFalse();
+        assertThat(shelter.getPhotoUrl()).isEqualTo("https://example.com/shelter1.jpg");
+    }
+
+    @Test
+    @DisplayName("비지오(이름/주소/시간/수용인원 등)만 변경되면 locationChanged=false")
+    void updateShelterInfo_nonGeoChanged() {
+        // given
+        Shelter s = newShelter();
+        ExternalShelterItem ext = newItem(
+                2L, "을지로 무더위 쉼터 2", "서울 중구 을지로 45-2",
+                "37.5665", "126.9780",
+                100, 2, 1,
+                "0900", "1800", "1000", "1600",
+                "002"
+        );
+
+        // when
+        UpdateResultResponse res = s.updateShelterInfo(
+                ext,
+                LocalTime.of(9, 00),
+                LocalTime.of(18, 00),
+                LocalTime.of(10, 0),
+                LocalTime.of(16, 0)
+        );
+
+        // then
+        assertThat(res.isChanged()).isTrue();
+        assertThat(res.locationChanged()).isFalse();
+        assertThat(s.getName()).isEqualTo("을지로 무더위 쉼터 2");
+        assertThat(s.getAddress()).isEqualTo("서울 중구 을지로 45-2");
+        assertThat(s.getCapacity()).isEqualTo(100);
+        assertThat(s.getFanCount()).isEqualTo(2);
+        assertThat(s.getAirConditionerCount()).isEqualTo(1);
+        assertThat(s.getWeekdayOpenTime()).isEqualTo(LocalTime.of(9, 00));
+        assertThat(s.getWeekdayCloseTime()).isEqualTo(LocalTime.of(18, 00));
+        assertThat(s.getWeekendOpenTime()).isEqualTo(LocalTime.of(10, 0));
+        assertThat(s.getWeekendCloseTime()).isEqualTo(LocalTime.of(16, 0));
+        assertThat(s.getIsOutdoors()).isTrue();
+    }
+
+
+    private Shelter newShelter() {
+        return Shelter.builder()
                 .shelterId(1L)
-                .name("기존 쉼터")
-                .address("기존 주소")
-                .latitude(new BigDecimal("37.12345678"))
-                .longitude(new BigDecimal("127.12345678"))
-                .capacity(10)
-                .isOutdoors(false)
-                .fanCount(1)
+                .name("종로 무더위 쉼터")
+                .address("서울 종로구 세종대로 175")
+                .latitude(BigDecimal.valueOf(37.5665))
+                .longitude(BigDecimal.valueOf(126.9780))
+                .weekdayOpenTime(LocalTime.of(9, 0))
+                .weekdayCloseTime(LocalTime.of(18, 0))
+                .weekendOpenTime(LocalTime.of(10, 0))
+                .weekendCloseTime(LocalTime.of(16, 0))
+                .capacity(50)
+                .isOutdoors(true)
+                .fanCount(3)
                 .airConditionerCount(1)
-                .weekdayOpenTime(baseWeekdayOpen)
-                .weekdayCloseTime(baseWeekdayClose)
-                .weekendOpenTime(baseWeekendOpen)
-                .weekendCloseTime(baseWeekendClose)
+                .totalRating(14)
+                .reviewCount(5)
+                .photoUrl("https://example.com/shelter1.jpg")
                 .build();
     }
 
-    private ExternalShelterItem createExternalItemWithSameData(String facilityType) {
-        return new ExternalShelterItem(1L, "기존 쉼터", "기존 주소",
-                new BigDecimal("37.12345678"), new BigDecimal("127.12345678"),
-                10, 1, 1,
-                "0900", "1800", "1000", "1700", facilityType);
-    }
-
-    @Nested
-    @DisplayName("updateShelterInfo 메소드는")
-    class UpdateShelterInfoTest {
-
-        @Test
-        @DisplayName("변경 사항이 없으면 false를 반환한다")
-        void returnsFalse_whenNoChanges() {
-            ExternalShelterItem item = createExternalItemWithSameData("001");
-
-            boolean isChanged = shelter.updateShelterInfo(item, baseWeekdayOpen, baseWeekdayClose,
-                    baseWeekendOpen, baseWeekendClose);
-
-            assertThat(isChanged).isFalse();
-        }
-
-        @Test
-        @DisplayName("이름만 변경될 경우, 이름만 수정하고 true를 반환한다")
-        void returnsTrue_whenOnlyNameChanges() {
-            ExternalShelterItem item = new ExternalShelterItem(1L, "새로운 쉼터", "기존 주소",
-                    new BigDecimal("37.12345678"), new BigDecimal("127.12345678"),
-                    10, 1, 1,
-                    "0900", "1800", "1000", "1700", "001");
-
-            boolean isChanged = shelter.updateShelterInfo(item, baseWeekdayOpen, baseWeekdayClose,
-                    baseWeekendOpen, baseWeekendClose);
-
-            assertSoftly(softly -> {
-                softly.assertThat(isChanged).isTrue();
-                softly.assertThat(shelter.getName()).isEqualTo("새로운 쉼터");
-                softly.assertThat(shelter.getAddress()).isEqualTo("기존 주소");
-                softly.assertThat(shelter.getLatitude()).isEqualByComparingTo("37.12345678");
-                softly.assertThat(shelter.getLongitude()).isEqualByComparingTo("127.12345678");
-                softly.assertThat(shelter.getCapacity()).isEqualTo(10);
-                softly.assertThat(shelter.getFanCount()).isEqualTo(1);
-                softly.assertThat(shelter.getAirConditionerCount()).isEqualTo(1);
-                softly.assertThat(shelter.getWeekdayOpenTime()).isEqualTo(baseWeekdayOpen);
-                softly.assertThat(shelter.getWeekdayCloseTime()).isEqualTo(baseWeekdayClose);
-                softly.assertThat(shelter.getWeekendOpenTime()).isEqualTo(baseWeekendOpen);
-                softly.assertThat(shelter.getWeekendCloseTime()).isEqualTo(baseWeekendClose);
-                softly.assertThat(shelter.getIsOutdoors()).isFalse();
-            });
-        }
-
-        @Test
-        @DisplayName("모든 필드가 변경될 경우, 모든 필드를 수정하고 true를 반환한다")
-        void returnsTrue_whenAllFieldsChange() {
-            LocalTime newWeekdayOpen = LocalTime.of(8, 0);
-            LocalTime newWeekdayClose = LocalTime.of(20, 0);
-            LocalTime newWeekendOpen = LocalTime.of(11, 0);
-            LocalTime newWeekendClose = LocalTime.of(16, 0);
-
-            ExternalShelterItem item = new ExternalShelterItem(1L, "전부 새로운 쉼터", "전부 새로운 주소",
-                    new BigDecimal("35.98765432"), new BigDecimal("128.98765432"),
-                    20, 2, 3,
-                    "0800", "2000", "1100", "1600", "002");
-
-            boolean isChanged = shelter.updateShelterInfo(item, newWeekdayOpen, newWeekdayClose,
-                    newWeekendOpen, newWeekendClose);
-
-            assertSoftly(softly -> {
-                softly.assertThat(isChanged).isTrue();
-                softly.assertThat(shelter.getName()).isEqualTo("전부 새로운 쉼터");
-                softly.assertThat(shelter.getAddress()).isEqualTo("전부 새로운 주소");
-                softly.assertThat(shelter.getLatitude()).isEqualByComparingTo("35.98765432");
-                softly.assertThat(shelter.getLongitude()).isEqualByComparingTo("128.98765432");
-                softly.assertThat(shelter.getCapacity()).isEqualTo(20);
-                softly.assertThat(shelter.getFanCount()).isEqualTo(2);
-                softly.assertThat(shelter.getAirConditionerCount()).isEqualTo(3);
-                softly.assertThat(shelter.getWeekdayOpenTime()).isEqualTo(newWeekdayOpen);
-                softly.assertThat(shelter.getWeekdayCloseTime()).isEqualTo(newWeekdayClose);
-                softly.assertThat(shelter.getWeekendOpenTime()).isEqualTo(newWeekendOpen);
-                softly.assertThat(shelter.getWeekendCloseTime()).isEqualTo(newWeekendClose);
-                softly.assertThat(shelter.getIsOutdoors()).isTrue();
-            });
-        }
-
-        @Test
-        @DisplayName("시설 타입 코드가 '002'로 변경되면 isOutdoors 필드를 true로 업데이트한다")
-        void updatesIsOutdoorsToTrue_whenFacilityTypeChangesToOutdoor() {
-            ExternalShelterItem item = createExternalItemWithSameData("002");
-
-            boolean isChanged = shelter.updateShelterInfo(item, baseWeekdayOpen, baseWeekdayClose,
-                    baseWeekendOpen, baseWeekendClose);
-
-            assertThat(isChanged).isTrue();
-            assertThat(shelter.getIsOutdoors()).isTrue();
-        }
-
-        @Test
-        @DisplayName("isOutdoors가 true였다가 시설 타입 코드가 '002'가 아니게 되면 false로 업데이트한다")
-        void updatesIsOutdoorsToFalse_whenFacilityTypeChangesToIndoor() {
-            ExternalShelterItem outdoorItem = createExternalItemWithSameData("002");
-            shelter.updateShelterInfo(outdoorItem, baseWeekdayOpen, baseWeekdayClose,
-                    baseWeekendOpen, baseWeekendClose);
-            assertThat(shelter.getIsOutdoors()).isTrue();
-
-            ExternalShelterItem indoorItem = createExternalItemWithSameData("001");
-            boolean isChanged = shelter.updateShelterInfo(indoorItem, baseWeekdayOpen,
-                    baseWeekdayClose, baseWeekendOpen, baseWeekendClose);
-
-            assertThat(isChanged).isTrue();
-            assertThat(shelter.getIsOutdoors()).isFalse();
-        }
-    }
-
-    @Nested
-    @DisplayName("toShelter 정적 팩토리 메소드는")
-    class ToShelterTest {
-
-        @Test
-        @DisplayName("ExternalShelterItem을 Shelter 엔티티로 올바르게 변환한다")
-        void convertsExternalItemToShelterEntity() {
-            ExternalShelterItem item = new ExternalShelterItem(1L, "테스트 쉼터", "테스트 주소",
-                    new BigDecimal("37.123"), new BigDecimal("127.456"),
-                    50, 5, 2,
-                    "0900", "1800", "1000", "1700", "002");
-
-            Shelter convertedShelter = Shelter.toShelter(item);
-
-            assertSoftly(softly -> {
-                softly.assertThat(convertedShelter.getShelterId()).isEqualTo(1L);
-                softly.assertThat(convertedShelter.getName()).isEqualTo("테스트 쉼터");
-                softly.assertThat(convertedShelter.getAddress()).isEqualTo("테스트 주소");
-                softly.assertThat(convertedShelter.getLatitude()).isEqualByComparingTo("37.123");
-                softly.assertThat(convertedShelter.getLongitude()).isEqualByComparingTo("127.456");
-                softly.assertThat(convertedShelter.getCapacity()).isEqualTo(50);
-                softly.assertThat(convertedShelter.getFanCount()).isEqualTo(5);
-                softly.assertThat(convertedShelter.getAirConditionerCount()).isEqualTo(2);
-                softly.assertThat(convertedShelter.getWeekdayOpenTime())
-                        .isEqualTo(LocalTime.of(9, 0));
-                softly.assertThat(convertedShelter.getWeekdayCloseTime())
-                        .isEqualTo(LocalTime.of(18, 0));
-                softly.assertThat(convertedShelter.getWeekendOpenTime())
-                        .isEqualTo(LocalTime.of(10, 0));
-                softly.assertThat(convertedShelter.getWeekendCloseTime())
-                        .isEqualTo(LocalTime.of(17, 0));
-                softly.assertThat(convertedShelter.getIsOutdoors()).isTrue(); // 002는 true
-                softly.assertThat(convertedShelter.getPhotoUrl()).isNull();
-            });
-        }
+    private ExternalShelterItem newItem(
+            Long id, String name, String addr,
+            String la, String lo, Integer cap,
+            Integer fan, Integer ac,
+            String wkOpen, String wkClose,
+            String weOpen, String weClose,
+            String fcltyTy
+    ) {
+        return new ExternalShelterItem(
+                id, name, addr,
+                new BigDecimal(la), new BigDecimal(lo),
+                cap, fan, ac,
+                wkOpen, wkClose, weOpen, weClose,
+                fcltyTy
+        );
     }
 }
-

--- a/src/test/java/com/team19/musuimsa/shelter/domain/ShelterTest.java
+++ b/src/test/java/com/team19/musuimsa/shelter/domain/ShelterTest.java
@@ -2,145 +2,254 @@ package com.team19.musuimsa.shelter.domain;
 
 import com.team19.musuimsa.shelter.dto.UpdateResultResponse;
 import com.team19.musuimsa.shelter.dto.external.ExternalShelterItem;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.time.LocalTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
+@DisplayName("Shelter 엔티티 테스트")
 class ShelterTest {
 
-    @Test
-    @DisplayName("photoUrl이 새 값으로 변경되면 true 반환하고 필드가 갱신된다")
-    void updatePhotoUrl_success_whenDifferent() {
-        // given
-        Shelter shelter = newShelter();
+    private Shelter shelter;
+    private final LocalTime baseWeekdayOpen = LocalTime.of(9, 0);
+    private final LocalTime baseWeekdayClose = LocalTime.of(18, 0);
+    private final LocalTime baseWeekendOpen = LocalTime.of(10, 0);
+    private final LocalTime baseWeekendClose = LocalTime.of(17, 0);
 
-        // when
-        boolean changed = shelter.updatePhotoUrl("https://example.com/after.jpg");
-
-        // then
-        assertThat(changed).isTrue();
-        assertThat(shelter.getPhotoUrl()).isEqualTo("https://example.com/after.jpg");
-    }
-
-    @Test
-    @DisplayName("photoUrl이 동일하면 false 반환하고 값이 유지된다")
-    void updatePhotoUrl_noop_whenSame() {
-        // given
-        Shelter shelter = newShelter();
-
-        // when
-        boolean changed = shelter.updatePhotoUrl("https://example.com/shelter1.jpg");
-
-        // then
-        assertThat(changed).isFalse();
-        assertThat(shelter.getPhotoUrl()).isEqualTo("https://example.com/shelter1.jpg");
-    }
-
-    @Test
-    @DisplayName("photoUrl이 null이면 false 반환하고 변경하지 않는다")
-    void updatePhotoUrl_noop_whenNull() {
-        // given
-        Shelter shelter = newShelter();
-
-        // when
-        boolean changed = shelter.updatePhotoUrl(null);
-
-        // then
-        assertThat(changed).isFalse();
-        assertThat(shelter.getPhotoUrl()).isEqualTo("https://example.com/shelter1.jpg");
-    }
-
-    @Test
-    @DisplayName("photoUrl이 공백이면 false 반환하고 변경하지 않는다")
-    void updatePhotoUrl_noop_whenBlank() {
-        // given
-        Shelter shelter = newShelter();
-
-        // when
-        boolean changed = shelter.updatePhotoUrl("   ");
-
-        // then
-        assertThat(changed).isFalse();
-        assertThat(shelter.getPhotoUrl()).isEqualTo("https://example.com/shelter1.jpg");
-    }
-
-    @Test
-    @DisplayName("비지오(이름/주소/시간/수용인원 등)만 변경되면 locationChanged=false")
-    void updateShelterInfo_nonGeoChanged() {
-        // given
-        Shelter s = newShelter();
-        ExternalShelterItem ext = newItem(
-                2L, "을지로 무더위 쉼터 2", "서울 중구 을지로 45-2",
-                "37.5665", "126.9780",
-                100, 2, 1,
-                "0900", "1800", "1000", "1600",
-                "002"
-        );
-
-        // when
-        UpdateResultResponse res = s.updateShelterInfo(
-                ext,
-                LocalTime.of(9, 00),
-                LocalTime.of(18, 00),
-                LocalTime.of(10, 0),
-                LocalTime.of(16, 0)
-        );
-
-        // then
-        assertThat(res.isChanged()).isTrue();
-        assertThat(res.locationChanged()).isFalse();
-        assertThat(s.getName()).isEqualTo("을지로 무더위 쉼터 2");
-        assertThat(s.getAddress()).isEqualTo("서울 중구 을지로 45-2");
-        assertThat(s.getCapacity()).isEqualTo(100);
-        assertThat(s.getFanCount()).isEqualTo(2);
-        assertThat(s.getAirConditionerCount()).isEqualTo(1);
-        assertThat(s.getWeekdayOpenTime()).isEqualTo(LocalTime.of(9, 00));
-        assertThat(s.getWeekdayCloseTime()).isEqualTo(LocalTime.of(18, 00));
-        assertThat(s.getWeekendOpenTime()).isEqualTo(LocalTime.of(10, 0));
-        assertThat(s.getWeekendCloseTime()).isEqualTo(LocalTime.of(16, 0));
-        assertThat(s.getIsOutdoors()).isTrue();
-    }
-
-
-    private Shelter newShelter() {
-        return Shelter.builder()
+    @BeforeEach
+    void setUp() {
+        shelter = Shelter.builder()
                 .shelterId(1L)
-                .name("종로 무더위 쉼터")
-                .address("서울 종로구 세종대로 175")
-                .latitude(BigDecimal.valueOf(37.5665))
-                .longitude(BigDecimal.valueOf(126.9780))
-                .weekdayOpenTime(LocalTime.of(9, 0))
-                .weekdayCloseTime(LocalTime.of(18, 0))
-                .weekendOpenTime(LocalTime.of(10, 0))
-                .weekendCloseTime(LocalTime.of(16, 0))
-                .capacity(50)
-                .isOutdoors(true)
-                .fanCount(3)
+                .name("기존 쉼터")
+                .address("기존 주소")
+                .latitude(new BigDecimal("37.12345678"))
+                .longitude(new BigDecimal("127.12345678"))
+                .capacity(10)
+                .isOutdoors(false)
+                .fanCount(1)
                 .airConditionerCount(1)
-                .totalRating(14)
-                .reviewCount(5)
-                .photoUrl("https://example.com/shelter1.jpg")
+                .weekdayOpenTime(baseWeekdayOpen)
+                .weekdayCloseTime(baseWeekdayClose)
+                .weekendOpenTime(baseWeekendOpen)
+                .weekendCloseTime(baseWeekendClose)
+                .photoUrl(null)
                 .build();
     }
 
-    private ExternalShelterItem newItem(
-            Long id, String name, String addr,
-            String la, String lo, Integer cap,
-            Integer fan, Integer ac,
-            String wkOpen, String wkClose,
-            String weOpen, String weClose,
-            String fcltyTy
-    ) {
+    private ExternalShelterItem createExternalItemWithSameData(String facilityType) {
         return new ExternalShelterItem(
-                id, name, addr,
-                new BigDecimal(la), new BigDecimal(lo),
-                cap, fan, ac,
-                wkOpen, wkClose, weOpen, weClose,
-                fcltyTy
+                1L, "기존 쉼터", "기존 주소",
+                new BigDecimal("37.12345678"), new BigDecimal("127.12345678"),
+                10, 1, 1,
+                "0900", "1800", "1000", "1700", facilityType
         );
+    }
+
+    @Nested
+    @DisplayName("updateShelterInfo 메소드는")
+    class UpdateShelterInfoTest {
+
+        @Test
+        @DisplayName("변경 사항이 없으면 false를 반환한다")
+        void returnsFalse_whenNoChanges() {
+            ExternalShelterItem item = createExternalItemWithSameData("001");
+
+            UpdateResultResponse res = shelter.updateShelterInfo(
+                    item, baseWeekdayOpen, baseWeekdayClose, baseWeekendOpen, baseWeekendClose
+            );
+
+            assertThat(res.isChanged()).isFalse();
+            assertThat(res.locationChanged()).isFalse();
+        }
+
+        @Test
+        @DisplayName("이름만 변경될 경우, 이름만 수정하고 true를 반환한다")
+        void returnsTrue_whenOnlyNameChanges() {
+            ExternalShelterItem item = new ExternalShelterItem(
+                    1L, "새로운 쉼터", "기존 주소",
+                    new BigDecimal("37.12345678"), new BigDecimal("127.12345678"),
+                    10, 1, 1,
+                    "0900", "1800", "1000", "1700", "001"
+            );
+
+            UpdateResultResponse res = shelter.updateShelterInfo(
+                    item, baseWeekdayOpen, baseWeekdayClose, baseWeekendOpen, baseWeekendClose
+            );
+
+            assertSoftly(softly -> {
+                softly.assertThat(res.isChanged()).isTrue();
+                softly.assertThat(res.locationChanged()).isFalse();
+                softly.assertThat(shelter.getName()).isEqualTo("새로운 쉼터");
+                softly.assertThat(shelter.getAddress()).isEqualTo("기존 주소");
+                softly.assertThat(shelter.getLatitude()).isEqualByComparingTo("37.12345678");
+                softly.assertThat(shelter.getLongitude()).isEqualByComparingTo("127.12345678");
+                softly.assertThat(shelter.getCapacity()).isEqualTo(10);
+                softly.assertThat(shelter.getFanCount()).isEqualTo(1);
+                softly.assertThat(shelter.getAirConditionerCount()).isEqualTo(1);
+                softly.assertThat(shelter.getWeekdayOpenTime()).isEqualTo(baseWeekdayOpen);
+                softly.assertThat(shelter.getWeekdayCloseTime()).isEqualTo(baseWeekdayClose);
+                softly.assertThat(shelter.getWeekendOpenTime()).isEqualTo(baseWeekendOpen);
+                softly.assertThat(shelter.getWeekendCloseTime()).isEqualTo(baseWeekendClose);
+                softly.assertThat(shelter.getIsOutdoors()).isFalse();
+            });
+        }
+
+        @Test
+        @DisplayName("비지오(이름/주소/시간/수용인원 등)만 변경되면 locationChanged=false")
+        void nonGeoChanged_locationFalse() {
+            ExternalShelterItem item = new ExternalShelterItem(
+                    1L, "을지로 무더위 쉼터 2", "서울 중구 을지로 45-2",
+                    new BigDecimal("37.12345678"), new BigDecimal("127.12345678"), // 위경도 동일
+                    100, 2, 1,
+                    "0900", "1800", "1000", "1600",
+                    "002"
+            );
+
+            UpdateResultResponse res = shelter.updateShelterInfo(
+                    item, LocalTime.of(9, 0), LocalTime.of(18, 0),
+                    LocalTime.of(10, 0), LocalTime.of(16, 0)
+            );
+
+            assertThat(res.isChanged()).isTrue();
+            assertThat(res.locationChanged()).isFalse();
+            assertThat(shelter.getName()).isEqualTo("을지로 무더위 쉼터 2");
+            assertThat(shelter.getAddress()).isEqualTo("서울 중구 을지로 45-2");
+            assertThat(shelter.getCapacity()).isEqualTo(100);
+            assertThat(shelter.getIsOutdoors()).isTrue();
+        }
+
+        @Test
+        @DisplayName("위/경도가 변경되면 locationChanged=true")
+        void geoChanged_locationTrue() {
+            ExternalShelterItem item = new ExternalShelterItem(
+                    1L, "전부 새로운 쉼터", "전부 새로운 주소",
+                    new BigDecimal("35.98765432"), new BigDecimal("128.98765432"), // 위경도 변경
+                    20, 2, 3,
+                    "0800", "2000", "1100", "1600", "002"
+            );
+
+            UpdateResultResponse res = shelter.updateShelterInfo(
+                    item, LocalTime.of(8, 0), LocalTime.of(20, 0),
+                    LocalTime.of(11, 0), LocalTime.of(16, 0)
+            );
+
+            assertSoftly(softly -> {
+                softly.assertThat(res.isChanged()).isTrue();
+                softly.assertThat(res.locationChanged()).isTrue();
+                softly.assertThat(shelter.getLatitude()).isEqualByComparingTo("35.98765432");
+                softly.assertThat(shelter.getLongitude()).isEqualByComparingTo("128.98765432");
+                softly.assertThat(shelter.getIsOutdoors()).isTrue();
+            });
+        }
+
+        @Test
+        @DisplayName("시설 타입 코드가 '002'면 isOutdoors=true")
+        void updatesIsOutdoorsToTrue_whenFacilityTypeChangesToOutdoor() {
+            ExternalShelterItem item = createExternalItemWithSameData("002");
+
+            UpdateResultResponse res = shelter.updateShelterInfo(
+                    item, baseWeekdayOpen, baseWeekdayClose, baseWeekendOpen, baseWeekendClose
+            );
+
+            assertThat(res.isChanged()).isTrue();
+            assertThat(res.locationChanged()).isFalse();
+            assertThat(shelter.getIsOutdoors()).isTrue();
+        }
+
+        @Test
+        @DisplayName("기존 true였다가 시설 타입이 '002'가 아니면 false로 변경")
+        void updatesIsOutdoorsToFalse_whenFacilityTypeChangesToIndoor() {
+            // 먼저 야외로 변경해 둠
+            ExternalShelterItem outdoorItem = createExternalItemWithSameData("002");
+            shelter.updateShelterInfo(outdoorItem, baseWeekdayOpen, baseWeekdayClose,
+                    baseWeekendOpen, baseWeekendClose);
+            assertThat(shelter.getIsOutdoors()).isTrue();
+
+            // 실내로 변경
+            ExternalShelterItem indoorItem = createExternalItemWithSameData("001");
+            UpdateResultResponse res = shelter.updateShelterInfo(
+                    indoorItem, baseWeekdayOpen, baseWeekdayClose, baseWeekendOpen, baseWeekendClose
+            );
+
+            assertThat(res.isChanged()).isTrue();
+            assertThat(res.locationChanged()).isFalse();
+            assertThat(shelter.getIsOutdoors()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("updatePhotoUrl 메소드는")
+    class UpdatePhotoUrlTest {
+
+        @Test
+        @DisplayName("null/blank 값이면 false 반환하고 변경하지 않는다")
+        void returnsFalse_whenNullOrBlank() {
+            assertThat(shelter.updatePhotoUrl(null)).isFalse();
+            assertThat(shelter.updatePhotoUrl("")).isFalse();
+            assertThat(shelter.getPhotoUrl()).isNull();
+        }
+
+        @Test
+        @DisplayName("같은 URL로 호출하면 false 반환")
+        void returnsFalse_whenSameUrl() {
+            String url = "https://mock.example/shelters/1.jpg";
+            assertThat(shelter.updatePhotoUrl(url)).isTrue();   // 최초 설정
+            assertThat(shelter.updatePhotoUrl(url)).isFalse();  // 동일 값
+            assertThat(shelter.getPhotoUrl()).isEqualTo(url);
+        }
+
+        @Test
+        @DisplayName("다른 URL이면 값 업데이트 후 true 반환")
+        void returnsTrue_whenDifferentUrl() {
+            String oldUrl = "https://mock.example/shelters/1.jpg";
+            String newUrl = "https://mock.example/shelters/1_v2.jpg";
+
+            shelter.updatePhotoUrl(oldUrl);
+            boolean changed = shelter.updatePhotoUrl(newUrl);
+
+            assertThat(changed).isTrue();
+            assertThat(shelter.getPhotoUrl()).isEqualTo(newUrl);
+        }
+    }
+
+    @Nested
+    @DisplayName("toShelter 정적 팩토리 메소드는")
+    class ToShelterTest {
+
+        @Test
+        @DisplayName("ExternalShelterItem을 Shelter 엔티티로 올바르게 변환한다")
+        void convertsExternalItemToShelterEntity() {
+            ExternalShelterItem item = new ExternalShelterItem(
+                    1L, "테스트 쉼터", "테스트 주소",
+                    new BigDecimal("37.123"), new BigDecimal("127.456"),
+                    50, 5, 2,
+                    "0900", "1800", "1000", "1700", "002"
+            );
+
+            Shelter converted = Shelter.toShelter(item);
+
+            assertSoftly(softly -> {
+                softly.assertThat(converted.getShelterId()).isEqualTo(1L);
+                softly.assertThat(converted.getName()).isEqualTo("테스트 쉼터");
+                softly.assertThat(converted.getAddress()).isEqualTo("테스트 주소");
+                softly.assertThat(converted.getLatitude()).isEqualByComparingTo("37.123");
+                softly.assertThat(converted.getLongitude()).isEqualByComparingTo("127.456");
+                softly.assertThat(converted.getCapacity()).isEqualTo(50);
+                softly.assertThat(converted.getFanCount()).isEqualTo(5);
+                softly.assertThat(converted.getAirConditionerCount()).isEqualTo(2);
+                softly.assertThat(converted.getWeekdayOpenTime()).isEqualTo(LocalTime.of(9, 0));
+                softly.assertThat(converted.getWeekdayCloseTime()).isEqualTo(LocalTime.of(18, 0));
+                softly.assertThat(converted.getWeekendOpenTime()).isEqualTo(LocalTime.of(10, 0));
+                softly.assertThat(converted.getWeekendCloseTime()).isEqualTo(LocalTime.of(17, 0));
+                softly.assertThat(converted.getIsOutdoors()).isTrue();
+                softly.assertThat(converted.getPhotoUrl()).isNull();
+            });
+        }
     }
 }

--- a/src/test/java/com/team19/musuimsa/shelter/service/ShelterPhotoFlowE2ETest.java
+++ b/src/test/java/com/team19/musuimsa/shelter/service/ShelterPhotoFlowE2ETest.java
@@ -1,0 +1,147 @@
+package com.team19.musuimsa.shelter.service;
+
+import com.adobe.testing.s3mock.junit5.S3MockExtension;
+import com.team19.musuimsa.shelter.domain.Shelter;
+import com.team19.musuimsa.shelter.repository.ShelterRepository;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okio.Buffer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class ShelterPhotoFlowE2ETest {
+
+    static MockWebServer mapillary = new MockWebServer();
+
+    @RegisterExtension
+    static S3MockExtension s3 = S3MockExtension.builder()
+            .withSecureConnection(false)
+            .silent()
+            .build();
+
+    @Autowired
+    ShelterRepository shelterRepository;
+
+    @Autowired
+    ShelterPhotoService shelterPhotoService;
+
+    @Autowired
+    S3Client s3Client;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        mapillary.start();
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        mapillary.shutdown();
+    }
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry r) {
+        r.add("aws.s3.region", () -> "ap-northeast-2");
+        r.add("aws.s3.bucket", () -> "musuimsa");
+        r.add("aws.s3.folder", () -> "shelters");
+        r.add("aws.s3.base-url", () -> "https://mock-s3.local");
+        r.add("aws.s3.endpoint", () -> s3.getServiceEndpoint());
+        r.add("mapillary.api-base", () -> "http://localhost:" + mapillary.getPort());
+        r.add("mapillary.access-token", () -> "dummy");
+    }
+
+    @Test
+    void flow() {
+        final String bucket = "musuimsa";
+        try {
+            s3Client.headBucket(b -> b.bucket(bucket));
+        } catch (Exception ignored) {
+            s3Client.createBucket(b -> b.bucket(bucket));
+        }
+
+        // 1) /images 응답 페이크 (썸네일/좌표 포함)
+        long shelterId = 1L;
+        double lat = 37.5665;
+        double lon = 126.9780;
+
+        String thumbPath = "/thumbs/" + shelterId + ".jpg";
+        String thumbAbsUrl = "http://localhost:" + mapillary.getPort() + thumbPath;
+
+        String imagesJson = """
+                {
+                  "data": [
+                    {
+                      "id": "IMG_1",
+                      "thumb_2048_url": "%s",
+                      "computed_geometry": {
+                        "type": "Point",
+                        "coordinates": [ %f, %f ]
+                      },
+                      "captured_at": 1700000000000
+                    }
+                  ]
+                }
+                """.formatted(thumbAbsUrl, lon, lat);
+
+        mapillary.enqueue(new MockResponse()
+                .setResponseCode(HttpStatus.OK.value())
+                .addHeader("Content-Type", "application/json")
+                .setBody(imagesJson));
+
+        // 2) 썸네일 바이트 응답 페이크
+        byte[] imageBytes = "FAKE_JPEG_BYTES".getBytes(StandardCharsets.UTF_8);
+        mapillary.enqueue(new MockResponse()
+                .setResponseCode(HttpStatus.OK.value())
+                .addHeader("Content-Type", "image/jpeg")
+                .setBody(new Buffer().write(imageBytes)));
+
+        // 3) Shelter 생성 및 저장
+        Shelter shelter = Shelter.builder()
+                .shelterId(shelterId)
+                .name("종로 무더위 쉼터")
+                .address("서울 종로구 세종대로 175")
+                .latitude(BigDecimal.valueOf(lat))
+                .longitude(BigDecimal.valueOf(lon))
+                .isOutdoors(false)
+                .capacity(50)
+                .fanCount(3)
+                .airConditionerCount(1)
+                .build();
+        shelterRepository.saveAndFlush(shelter);
+
+        boolean updated = shelterPhotoService.updatePhoto(shelterId);
+
+        assertTrue(updated, "사진 갱신이 true 여야 함");
+
+        Shelter saved = shelterRepository.findById(shelterId).orElseThrow();
+        String expectedUrl = "https://mock-s3.local/shelters/" + shelterId + ".jpg";
+        assertEquals(expectedUrl, saved.getPhotoUrl(), "DB photoUrl이 예상 공개 URL이어야 함");
+
+        // S3Mock에 실제 업로드 되었는지 확인
+        ResponseBytes<GetObjectResponse> got = s3Client.getObjectAsBytes(
+                GetObjectRequest.builder()
+                        .bucket("musuimsa")
+                        .key("shelters/" + shelterId + ".jpg")
+                        .build()
+        );
+        assertArrayEquals(imageBytes, got.asByteArray(), "S3에 업로드된 바이트가 썸네일과 동일해야 함");
+
+        assertEquals(0, mapillary.getRequestCount() - 2, "Mapillary 호출 횟수 확인");
+    }
+}

--- a/src/test/java/com/team19/musuimsa/shelter/service/ShelterPhotoFlowE2ETest.java
+++ b/src/test/java/com/team19/musuimsa/shelter/service/ShelterPhotoFlowE2ETest.java
@@ -62,7 +62,6 @@ class ShelterPhotoFlowE2ETest {
         r.add("aws.s3.folder", () -> "shelters");
         r.add("aws.s3.base-url", () -> "https://mock-s3.local");
         r.add("aws.s3.endpoint", () -> s3.getServiceEndpoint());
-        r.add("aws.s3.path-style-access", () -> "true");
         r.add("mapillary.api-base", () -> "http://localhost:" + mapillary.getPort());
         r.add("mapillary.access-token", () -> "dummy");
     }

--- a/src/test/java/com/team19/musuimsa/shelter/service/ShelterPhotoFlowE2ETest.java
+++ b/src/test/java/com/team19/musuimsa/shelter/service/ShelterPhotoFlowE2ETest.java
@@ -62,6 +62,7 @@ class ShelterPhotoFlowE2ETest {
         r.add("aws.s3.folder", () -> "shelters");
         r.add("aws.s3.base-url", () -> "https://mock-s3.local");
         r.add("aws.s3.endpoint", () -> s3.getServiceEndpoint());
+        r.add("aws.s3.path-style-access", () -> "true");
         r.add("mapillary.api-base", () -> "http://localhost:" + mapillary.getPort());
         r.add("mapillary.access-token", () -> "dummy");
     }


### PR DESCRIPTION
### ✅ 작업 내용
- **사진 저장 로직**
    - 외부 API(Mapillary)를 통해 쉼터 사진 조회
    - 조회된 이미지를 AWS S3에 업로드
    - 업로드된 S3 URL을 DB의 photoUrl 필드에 반영

- **배치 로직 개선**
    - 기존에는 DB 필드가 변경된 모든 건에 대하여 쉼터에 대해 update를 진행했으나, 위·경도 값만 변경된 경우에도 사진 갱신이 일어나도록 수정
    - UpdateResultResponse(isChanged, locationChanged) DTO 추가 → 변경/위치변경 여부를 분리 관리
    - 배치/리스너(ShelterImportBatchConfig, ShelterUpdateJobListener)에서 locationChangedShelterIds를 따로 수집 후, 해당 ID에 한해 사진 갱신 처리

- **테스트 코드**
    - `photoUrl` 업데이트 로직 단위 테스트 추가
    - 배치 실행 시 위·경도 변경된 쉼터만 트리거되는지 검증하는 통합 테스트 작성
       (외부 API Fake, `ShelterPhotoService` Mock으로 호출 횟수/대상 검증)