### PR TITLE
[Weather] 위치 기반 현재 날씨 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,10 +77,3 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
-
-tasks.named("bootRun") {
-    systemProperty "spring.profiles.active", "dev" // JVM 인자 방식(B)
-    systemProperty "weather.kma.base-url", "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0"
-    systemProperty "weather.kma.allow-insecure", "true"
-}
-

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ dependencies {
     // Sprig Batch
     implementation 'org.springframework.boot:spring-boot-starter-batch'
 
+    // cache
+    implementation("org.springframework.boot:spring-boot-starter-cache")
+    implementation("com.github.ben-manes.caffeine:caffeine:3.1.8")
+
     // Lombok
     compileOnly 'org.projectlombok:lombok'
 
@@ -61,3 +65,10 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+tasks.named("bootRun") {
+    systemProperty "spring.profiles.active", "dev" // JVM 인자 방식(B)
+    systemProperty "weather.kma.base-url", "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0"
+    systemProperty "weather.kma.allow-insecure", "true"
+}
+

--- a/src/main/java/com/team19/musuimsa/config/CacheConfig.java
+++ b/src/main/java/com/team19/musuimsa/config/CacheConfig.java
@@ -2,6 +2,7 @@ package com.team19.musuimsa.config;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
@@ -12,11 +13,19 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class CacheConfig {
 
+    @Value("${spring.cache.caffeine.expire-after-write}")
+    private String expireAfterWrite;
+
+    @Value("${spring.cache.caffeine.maximum-size}")
+    private long maximumSize;
+
     @Bean
     public CacheManager cacheManager() {
+        Duration expiryDuration = Duration.parse("PT" + expireAfterWrite.toUpperCase());
+
         Caffeine<Object, Object> caffeine = Caffeine.newBuilder()
-                .expireAfterWrite(Duration.ofMinutes(3))
-                .maximumSize(10_000);
+                .expireAfterWrite(expiryDuration)
+                .maximumSize(maximumSize);
 
         CaffeineCacheManager manager = new CaffeineCacheManager();
         manager.setCaffeine(caffeine);

--- a/src/main/java/com/team19/musuimsa/config/CacheConfig.java
+++ b/src/main/java/com/team19/musuimsa/config/CacheConfig.java
@@ -1,0 +1,26 @@
+package com.team19.musuimsa.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.time.Duration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        Caffeine<Object, Object> caffeine = Caffeine.newBuilder()
+                .expireAfterWrite(Duration.ofMinutes(3))
+                .maximumSize(10_000);
+
+        CaffeineCacheManager manager = new CaffeineCacheManager();
+        manager.setCaffeine(caffeine);
+
+        return manager;
+    }
+}

--- a/src/main/java/com/team19/musuimsa/weather/controller/WeatherController.java
+++ b/src/main/java/com/team19/musuimsa/weather/controller/WeatherController.java
@@ -1,0 +1,24 @@
+package com.team19.musuimsa.weather.controller;
+
+import com.team19.musuimsa.weather.dto.WeatherResponse;
+import com.team19.musuimsa.weather.service.WeatherService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/weather")
+public class WeatherController {
+
+    private final WeatherService weatherService;
+
+    @GetMapping("/current")
+    public ResponseEntity<WeatherResponse> getCurrentTemp(@RequestParam double latitude,
+            @RequestParam double longitude) {
+        return ResponseEntity.ok(weatherService.getCurrentTemp(latitude, longitude));
+    }
+}

--- a/src/main/java/com/team19/musuimsa/weather/dto/KmaResponse.java
+++ b/src/main/java/com/team19/musuimsa/weather/dto/KmaResponse.java
@@ -1,0 +1,41 @@
+package com.team19.musuimsa.weather.dto;
+
+import java.util.List;
+
+public record KmaResponse(
+        Response response
+) {
+
+    public record Response(
+            Header header,
+            Body body
+    ) {
+
+    }
+
+    public record Header(
+            String resultCode,
+            String resultMsg
+    ) {
+
+    }
+
+    public record Body(
+            Items items
+    ) {
+
+    }
+
+    public record Items(
+            List<Item> item
+    ) {
+
+    }
+
+    public record Item(
+            String category,
+            String obsrValue
+    ) {
+
+    }
+}

--- a/src/main/java/com/team19/musuimsa/weather/dto/NxNy.java
+++ b/src/main/java/com/team19/musuimsa/weather/dto/NxNy.java
@@ -1,0 +1,5 @@
+package com.team19.musuimsa.weather.dto;
+
+public record NxNy(int nx, int ny) {
+
+}

--- a/src/main/java/com/team19/musuimsa/weather/dto/WeatherResponse.java
+++ b/src/main/java/com/team19/musuimsa/weather/dto/WeatherResponse.java
@@ -1,0 +1,9 @@
+package com.team19.musuimsa.weather.dto;
+
+public record WeatherResponse(
+        double temperature,
+        String baseDate,
+        String baseTime
+) {
+
+}

--- a/src/main/java/com/team19/musuimsa/weather/service/WeatherService.java
+++ b/src/main/java/com/team19/musuimsa/weather/service/WeatherService.java
@@ -72,6 +72,11 @@ public class WeatherService {
         return new WeatherResponse(t1h, baseTime.date(), baseTime.time());
     }
 
+    public String gridKey(double latitude, double longitude) {
+        NxNy grid = KmaGrid.fromLatLon(latitude, longitude);
+        return grid.nx() + "-" + grid.ny();
+    }
+    
     private Double fetchT1H(String baseDate, String baseTime, int nx, int ny) {
         URI uri = buildUri(baseDate, baseTime, nx, ny);
         String requestInfo = "base=" + baseDate + " " + baseTime + ", nx=" + nx + ", ny=" + ny;

--- a/src/main/java/com/team19/musuimsa/weather/service/WeatherService.java
+++ b/src/main/java/com/team19/musuimsa/weather/service/WeatherService.java
@@ -25,7 +25,7 @@ public class WeatherService {
 
     private final RestClient restClient;
 
-    @V alue("${weather.service-key}")
+    @Value("${weather.service-key}")
     private String serviceKey;
 
     @Value("${weather.kma.base-url}")
@@ -45,7 +45,7 @@ public class WeatherService {
         Double t1h = fetchT1H(base.date(), base.time(), g.nx(), g.ny());
 
         if (t1h == null) {
-            KmaTime.Base prev = KmaTime.minusHours(base, 1, kst);
+            KmaTime.Base prev = KmaTime.minusHours(base, 1);
             Double fallback = fetchT1H(prev.date(), prev.time(), g.nx(), g.ny());
             if (fallback != null) {
                 base = prev;

--- a/src/main/java/com/team19/musuimsa/weather/service/WeatherService.java
+++ b/src/main/java/com/team19/musuimsa/weather/service/WeatherService.java
@@ -123,16 +123,19 @@ public class WeatherService {
     }
 
     private String buildUrl(String baseDate, String baseTime, int nx, int ny) {
-        return UriComponentsBuilder.fromHttpUrl(baseUrl + "/getUltraSrtNcst")
-                .queryParam("serviceKey", serviceKey)
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(
+                        baseUrl + "/getUltraSrtNcst")
                 .queryParam("pageNo", 1)
                 .queryParam("numOfRows", 60)
                 .queryParam("dataType", "JSON")
                 .queryParam("base_date", baseDate)
                 .queryParam("base_time", baseTime)
                 .queryParam("nx", nx)
-                .queryParam("ny", ny)
-                .toUriString();
+                .queryParam("ny", ny);
+
+        String urlString = builder.toUriString();
+
+        return urlString + "&serviceKey=" + serviceKey;
     }
 
 }

--- a/src/main/java/com/team19/musuimsa/weather/service/WeatherService.java
+++ b/src/main/java/com/team19/musuimsa/weather/service/WeatherService.java
@@ -28,6 +28,8 @@ public class WeatherService {
 
     private final RestClient restClient;
 
+    private static final String KMA_SUCCESS_CODE = "00";
+
     @Value("${weather.service-key}")
     private String serviceKey;
 
@@ -76,7 +78,7 @@ public class WeatherService {
         NxNy grid = KmaGrid.fromLatLon(latitude, longitude);
         return grid.nx() + "-" + grid.ny();
     }
-    
+
     private Double fetchT1H(String baseDate, String baseTime, int nx, int ny) {
         URI uri = buildUri(baseDate, baseTime, nx, ny);
         String requestInfo = "base=" + baseDate + " " + baseTime + ", nx=" + nx + ", ny=" + ny;
@@ -93,7 +95,7 @@ public class WeatherService {
                 String code = header.resultCode();
                 String message = header.resultMsg();
 
-                if (code != null && !"00".equals(code)) {
+                if (code != null && !KMA_SUCCESS_CODE.equals(code)) {
                     log.warn("기상청 오류 resultCode={}, resultMsg={}, requestInfo={}", code, message,
                             requestInfo);
                     throw new ExternalApiException(requestInfo);

--- a/src/main/java/com/team19/musuimsa/weather/service/WeatherService.java
+++ b/src/main/java/com/team19/musuimsa/weather/service/WeatherService.java
@@ -72,11 +72,6 @@ public class WeatherService {
         return new WeatherResponse(t1h, baseTime.date(), baseTime.time());
     }
 
-    public String gridKey(double latitude, double longitude) {
-        NxNy grid = KmaGrid.fromLatLon(latitude, longitude);
-        return grid.nx() + "-" + grid.ny();
-    }
-
     private Double fetchT1H(String baseDate, String baseTime, int nx, int ny) {
         URI uri = buildUri(baseDate, baseTime, nx, ny);
         String requestInfo = "base=" + baseDate + " " + baseTime + ", nx=" + nx + ", ny=" + ny;

--- a/src/main/java/com/team19/musuimsa/weather/service/WeatherService.java
+++ b/src/main/java/com/team19/musuimsa/weather/service/WeatherService.java
@@ -1,0 +1,138 @@
+package com.team19.musuimsa.weather.service;
+
+import com.team19.musuimsa.exception.external.ExternalApiException;
+import com.team19.musuimsa.weather.dto.NxNy;
+import com.team19.musuimsa.weather.dto.WeatherResponse;
+import com.team19.musuimsa.weather.util.KmaGrid;
+import com.team19.musuimsa.weather.util.KmaTime;
+import jakarta.annotation.PostConstruct;
+import java.time.Clock;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WeatherService {
+
+    private final RestClient restClient;
+
+    @V alue("${weather.service-key}")
+    private String serviceKey;
+
+    @Value("${weather.kma.base-url}")
+    private String baseUrl;
+
+    @PostConstruct
+    void logConfig() {
+        log.info("[WeatherService] KMA baseUrl = {}", baseUrl);
+    }
+
+    @Cacheable(cacheNames = "t1h", key = "#root.target.gridKey(#latitude, #longitude)")
+    public WeatherResponse getCurrentTemp(double latitude, double longitude) {
+        NxNy g = KmaGrid.fromLatLon(latitude, longitude);
+        Clock kst = Clock.system(ZoneId.of("Asia/Seoul"));
+
+        KmaTime.Base base = KmaTime.latestBase(kst);
+        Double t1h = fetchT1H(base.date(), base.time(), g.nx(), g.ny());
+
+        if (t1h == null) {
+            KmaTime.Base prev = KmaTime.minusHours(base, 1, kst);
+            Double fallback = fetchT1H(prev.date(), prev.time(), g.nx(), g.ny());
+            if (fallback != null) {
+                base = prev;
+                t1h = fallback;
+            }
+        }
+
+        if (t1h == null) {
+            String url = buildUrl(base.date(), base.time(), g.nx(), g.ny());
+            String msg = "기상청 응답에 현재기온이 없음. nx=" + g.nx() + ", ny=" + g.ny()
+                    + ", base=" + base.date() + " " + base.time();
+            log.warn("{} / url={}", msg, url);
+            throw new ExternalApiException(url);
+        }
+
+        return new WeatherResponse(t1h, base.date(), base.time());
+    }
+
+    public String gridKey(double latitude, double longitude) {
+        NxNy g = KmaGrid.fromLatLon(latitude, longitude);
+        return g.nx() + "-" + g.ny();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Double fetchT1H(String baseDate, String baseTime, int nx, int ny) {
+        String url = buildUrl(baseDate, baseTime, nx, ny);
+        try {
+            Map<String, Object> resp = restClient.get().uri(url).retrieve().body(Map.class);
+            if (resp == null) {
+                return null;
+            }
+
+            Map<String, Object> response = (Map<String, Object>) resp.get("response");
+            if (response == null) {
+                return null;
+            }
+
+            Map<String, Object> header = (Map<String, Object>) response.get("header");
+            if (header != null) {
+                Object code = header.get("resultCode");
+                Object message = header.get("resultMsg");
+                if (code != null && !"00".equals(String.valueOf(code))) {
+                    log.warn("기상청 오류 resultCode={}, resultMsg={}, url={}", code, message, url);
+                    throw new ExternalApiException(url);
+                }
+            }
+
+            Map<String, Object> body = (Map<String, Object>) response.get("body");
+            if (body == null) {
+                return null;
+            }
+            Map<String, Object> items = (Map<String, Object>) body.get("items");
+            if (items == null) {
+                return null;
+            }
+            List<Map<String, Object>> list = (List<Map<String, Object>>) items.get("item");
+            if (list == null) {
+                return null;
+            }
+
+            for (Map<String, Object> m : list) {
+                if ("T1H".equals(m.get("category"))) {
+                    Object v = m.get("obsrValue");
+                    return v == null ? null : Double.valueOf(String.valueOf(v));
+                }
+            }
+            return null;
+        } catch (ExternalApiException e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn("기상청 호출 실패: {} - {} / url={}", e.getClass().getSimpleName(), e.getMessage(),
+                    url);
+            throw new ExternalApiException(url);
+        }
+    }
+
+    private String buildUrl(String baseDate, String baseTime, int nx, int ny) {
+        return UriComponentsBuilder.fromHttpUrl(baseUrl + "/getUltraSrtNcst")
+                .queryParam("serviceKey", serviceKey)
+                .queryParam("pageNo", 1)
+                .queryParam("numOfRows", 60)
+                .queryParam("dataType", "JSON")
+                .queryParam("base_date", baseDate)
+                .queryParam("base_time", baseTime)
+                .queryParam("nx", nx)
+                .queryParam("ny", ny)
+                .toUriString();
+    }
+
+}

--- a/src/main/java/com/team19/musuimsa/weather/util/KmaGrid.java
+++ b/src/main/java/com/team19/musuimsa/weather/util/KmaGrid.java
@@ -1,0 +1,38 @@
+package com.team19.musuimsa.weather.util;
+
+import com.team19.musuimsa.weather.dto.NxNy;
+
+public final class KmaGrid {
+
+    private KmaGrid() {
+    }
+
+    public static NxNy fromLatLon(double lat, double lon) {
+        final double RE = 6371.00877, GRID = 5.0, SLAT1 = 30.0, SLAT2 = 60.0, OLON = 126.0, OLAT = 38.0;
+        final double XO = 43.0, YO = 136.0, DEGRAD = Math.PI / 180.0;
+
+        double re = RE / GRID;
+        double slat1 = SLAT1 * DEGRAD, slat2 = SLAT2 * DEGRAD;
+        double olon = OLON * DEGRAD, olat = OLAT * DEGRAD;
+
+        double sn = Math.log(Math.cos(slat1) / Math.cos(slat2)) /
+                Math.log(Math.tan(Math.PI * 0.25 + slat2 * 0.5) / Math.tan(
+                        Math.PI * 0.25 + slat1 * 0.5));
+        double sf = Math.pow(Math.tan(Math.PI * 0.25 + slat1 * 0.5), sn) * Math.cos(slat1) / sn;
+        double ro = re * sf / Math.pow(Math.tan(Math.PI * 0.25 + olat * 0.5), sn);
+
+        double ra = re * sf / Math.pow(Math.tan(Math.PI * 0.25 + lat * DEGRAD * 0.5), sn);
+        double theta = lon * DEGRAD - olon;
+        if (theta > Math.PI) {
+            theta -= 2.0 * Math.PI;
+        }
+        if (theta < -Math.PI) {
+            theta += 2.0 * Math.PI;
+        }
+        theta *= sn;
+
+        int nx = (int) Math.floor(ra * Math.sin(theta) + XO + 0.5);
+        int ny = (int) Math.floor(ro - ra * Math.cos(theta) + YO + 0.5);
+        return new NxNy(nx, ny);
+    }
+}

--- a/src/main/java/com/team19/musuimsa/weather/util/KmaTime.java
+++ b/src/main/java/com/team19/musuimsa/weather/util/KmaTime.java
@@ -1,0 +1,38 @@
+package com.team19.musuimsa.weather.util;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+public final class KmaTime {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter D8 = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final DateTimeFormatter H4 = DateTimeFormatter.ofPattern("HHmm");
+
+    private KmaTime() {
+    }
+
+    public static Base latestBase(Clock clock) {
+        ZonedDateTime now = ZonedDateTime.now(clock);
+        ZonedDateTime hour = now.withMinute(0).withSecond(0).withNano(0);
+        if (now.getMinute() < 11) {
+            hour = hour.minusHours(1);
+        }
+        return new Base(D8.format(hour), H4.format(hour));
+    }
+    
+    public static Base minusHours(Base b, int h) {
+        ZonedDateTime z = ZonedDateTime.of(
+                LocalDate.parse(b.date(), D8).atTime(Integer.parseInt(b.time().substring(0, 2)), 0),
+                KST
+        ).minusHours(h);
+        return new Base(D8.format(z), H4.format(z));
+    }
+
+    public record Base(String date, String time) {
+
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -11,4 +11,3 @@ spring.jpa.hibernate.ddl-auto=update
 # SQL
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
-weather.kma.base-url=http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -11,3 +11,4 @@ spring.jpa.hibernate.ddl-auto=update
 # SQL
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+weather.kma.base-url=http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,4 @@ musuimsa.shelter.api.format=json
 spring.webflux.codec.max-in-memory-size=10MB
 spring.batch.job.enabled=false
 musuimsa.rest-client.timeout-seconds=5
+spring.cache.type=caffeine

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,5 +8,5 @@ musuimsa.shelter.api.page-size=1000
 musuimsa.shelter.api.format=json
 spring.webflux.codec.max-in-memory-size=10MB
 spring.batch.job.enabled=false
-musuimsa.rest-client.timeout-seconds=5
+musuimsa.rest-client.timeout-seconds=15
 spring.cache.type=caffeine

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,6 +11,8 @@ spring.batch.job.enabled=false
 musuimsa.rest-client.timeout-seconds=15
 spring.cache.type=caffeine
 weather.kma.base-url=http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0
+spring.cache.caffeine.expire-after-write=3m
+spring.cache.caffeine.maximum-size=10000
 # aws-s3
 aws.s3.region=ap-northeast-2
 aws.s3.bucket=musuimsa

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,7 +10,7 @@ spring.webflux.codec.max-in-memory-size=10MB
 spring.batch.job.enabled=false
 musuimsa.rest-client.timeout-seconds=15
 spring.cache.type=caffeine
-musuimsa.rest-client.timeout-seconds=5
+weather.kma.base-url=http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0
 # aws-s3
 aws.s3.region=ap-northeast-2
 aws.s3.bucket=musuimsa

--- a/src/test/java/com/team19/musuimsa/weather/controller/WeatherControllerTest.java
+++ b/src/test/java/com/team19/musuimsa/weather/controller/WeatherControllerTest.java
@@ -1,5 +1,6 @@
 package com.team19.musuimsa.weather.controller;
 
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -14,10 +15,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 
@@ -26,7 +27,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
         excludeAutoConfiguration = {SecurityAutoConfiguration.class},
         excludeFilters = @Filter(type = FilterType.ANNOTATION, classes = ControllerAdvice.class)
 )
-class WeatherControllerTest {
+public class WeatherControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -34,7 +35,7 @@ class WeatherControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @MockBean
+    @MockitoBean
     private WeatherService weatherService;
 
     @Test
@@ -43,8 +44,7 @@ class WeatherControllerTest {
         // Given
         WeatherResponse mockResponse = new WeatherResponse(30, "20251003", "1500");
 
-        given(weatherService.getCurrentTemp(36.3504, 127.3845))
-                .willReturn(mockResponse);
+        given(weatherService.getCurrentTemp(anyDouble(), anyDouble())).willReturn(mockResponse);
 
         // When & Then
         mockMvc.perform(get("/api/weather/current")
@@ -53,8 +53,8 @@ class WeatherControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.temperature").value(25.5))
-                .andExpect(jsonPath("$.baseDate").value("20250929"))
-                .andExpect(jsonPath("$.baseTime").value("1700"));
+                .andExpect(jsonPath("$.temperature").value(30))
+                .andExpect(jsonPath("$.baseDate").value("20251003"))
+                .andExpect(jsonPath("$.baseTime").value("1500"));
     }
 }

--- a/src/test/java/com/team19/musuimsa/weather/controller/WeatherControllerTest.java
+++ b/src/test/java/com/team19/musuimsa/weather/controller/WeatherControllerTest.java
@@ -1,0 +1,60 @@
+package com.team19.musuimsa.weather.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team19.musuimsa.weather.dto.WeatherResponse;
+import com.team19.musuimsa.weather.service.WeatherService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+
+@WebMvcTest(
+        controllers = WeatherController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class},
+        excludeFilters = @Filter(type = FilterType.ANNOTATION, classes = ControllerAdvice.class)
+)
+class WeatherControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private WeatherService weatherService;
+
+    @Test
+    @DisplayName("/api/weather/current 호출 시 200 OK와 날씨 정보를 반환한다")
+    void getCurrentTemp_ReturnsWeatherResponse_200OK() throws Exception {
+        // Given
+        WeatherResponse mockResponse = new WeatherResponse(30, "20251003", "1500");
+
+        given(weatherService.getCurrentTemp(36.3504, 127.3845))
+                .willReturn(mockResponse);
+
+        // When & Then
+        mockMvc.perform(get("/api/weather/current")
+                        .param("latitude", String.valueOf(36.3504))
+                        .param("longitude", String.valueOf(127.3845))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.temperature").value(25.5))
+                .andExpect(jsonPath("$.baseDate").value("20250929"))
+                .andExpect(jsonPath("$.baseTime").value("1700"));
+    }
+}

--- a/src/test/java/com/team19/musuimsa/weather/util/KmaGridTest.java
+++ b/src/test/java/com/team19/musuimsa/weather/util/KmaGridTest.java
@@ -1,0 +1,51 @@
+package com.team19.musuimsa.weather.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.team19.musuimsa.weather.dto.NxNy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class KmaGridTest {
+
+    // 1. 제주도 좌표
+    // 위도: 33.511389, 경도: 126.493889
+    // 예상 격자 좌표 : NX=52, NY=38
+    private static final double JEJU_LAT = 33.511389;
+    private static final double JEJU_LON = 126.493889;
+    private static final int JEJU_NX = 52;
+    private static final int JEJU_NY = 38;
+
+    // 2. 대전 좌표
+    // 위도: 36.3504119, 경도: 127.3845475
+    // 예상 격자 좌표 : NX=67, NY=100
+    private static final double DAEJEON_LAT = 36.3504119;
+    private static final double DAEJEON_LON = 127.3845475;
+    private static final int DAEJEON_NX = 67;
+    private static final int DAEJEON_NY = 100;
+
+    @Test
+    @DisplayName("제주도 좌표를 KMA 격자 좌표로 정확히 반환한다.")
+    void convertJejuToGridCorrectly() {
+        // when
+        NxNy result = KmaGrid.fromLatLon(JEJU_LAT, JEJU_LON);
+
+        // then
+        assertNotNull(result);
+        assertEquals(JEJU_NX, result.nx());
+        assertEquals(JEJU_NY, result.ny());
+    }
+
+    @Test
+    @DisplayName("대전 좌표를 KMA 격자 좌표로 정확히 반환한다.")
+    void convertDaejeonToGridCorrectly() {
+        // when
+        NxNy result = KmaGrid.fromLatLon(DAEJEON_LAT, DAEJEON_LON);
+
+        // then
+        assertNotNull(result);
+        assertEquals(DAEJEON_NX, result.nx());
+        assertEquals(DAEJEON_NY, result.ny());
+    }
+}

--- a/src/test/java/com/team19/musuimsa/weather/util/KmaTimeTest.java
+++ b/src/test/java/com/team19/musuimsa/weather/util/KmaTimeTest.java
@@ -1,0 +1,61 @@
+package com.team19.musuimsa.weather.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class KmaTimeTest {
+
+    private final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    @Test
+    @DisplayName("latestBase: 정시 11분 미만 - 이전 시간 자료 반환")
+    void latestBase_Before11Minutes() {
+        // KST 15:05 (11분 미만이므로 14:00 자료를 반환해야 함)
+        Clock clock = Clock.fixed(Instant.parse("2025-10-03T06:05:00Z"), KST);
+
+        KmaTime.Base base = KmaTime.latestBase(clock);
+
+        assertEquals("20251003", base.date());
+        assertEquals("1400", base.time()); // 15시 - 1시간 = 14시
+    }
+
+    @Test
+    @DisplayName("latestBase: 정시 11분 이후 - 현재 시간 자료 반환")
+    void latestBase_After11Minutes() {
+        // KST 15:15 (11분 이후이므로 15:00 자료를 반환해야 함)
+        Clock clock = Clock.fixed(Instant.parse("2025-10-03T06:15:00Z"), KST);
+
+        KmaTime.Base base = KmaTime.latestBase(clock);
+
+        assertEquals("20251003", base.date());
+        assertEquals("1500", base.time());
+    }
+
+    @Test
+    @DisplayName("minusHours: 2시간 전 시간 계산")
+    void minusHours_Subtract2Hours() {
+        KmaTime.Base current = new KmaTime.Base("20251003", "1400");
+
+        KmaTime.Base prev = KmaTime.minusHours(current, 2,
+                Clock.system(KST)); // Clock은 시간 계산에 큰 영향을 주지 않지만 필요
+
+        assertEquals("20251003", prev.date());
+        assertEquals("1200", prev.time());
+    }
+
+    @Test
+    @DisplayName("minusHours: 자정을 넘어가는 시간 계산")
+    void minusHours_CrossMidnight() {
+        KmaTime.Base current = new KmaTime.Base("20251003", "0100");
+
+        KmaTime.Base prev = KmaTime.minusHours(current, 3, Clock.system(KST)); // 1시 - 3시간 = 전날 22시
+
+        assertEquals("20251002", prev.date());
+        assertEquals("2200", prev.time());
+    }
+}

--- a/src/test/java/com/team19/musuimsa/weather/util/KmaTimeTest.java
+++ b/src/test/java/com/team19/musuimsa/weather/util/KmaTimeTest.java
@@ -41,8 +41,7 @@ class KmaTimeTest {
     void minusHours_Subtract2Hours() {
         KmaTime.Base current = new KmaTime.Base("20251003", "1400");
 
-        KmaTime.Base prev = KmaTime.minusHours(current, 2,
-                Clock.system(KST)); // Clock은 시간 계산에 큰 영향을 주지 않지만 필요
+        KmaTime.Base prev = KmaTime.minusHours(current, 2);
 
         assertEquals("20251003", prev.date());
         assertEquals("1200", prev.time());
@@ -53,7 +52,7 @@ class KmaTimeTest {
     void minusHours_CrossMidnight() {
         KmaTime.Base current = new KmaTime.Base("20251003", "0100");
 
-        KmaTime.Base prev = KmaTime.minusHours(current, 3, Clock.system(KST)); // 1시 - 3시간 = 전날 22시
+        KmaTime.Base prev = KmaTime.minusHours(current, 3);
 
         assertEquals("20251002", prev.date());
         assertEquals("2200", prev.time());


### PR DESCRIPTION
## 주요 작업 내용
- 기상청 동네예보 조회서비스 2.0 - 초단기실황 `/getUltraSrtNcst` 사용하여 구현
  - 기상청에선 10분마다 현재 기온 데이터를 갱신하지만, 정각 단위로만 API 요청이 가능하기에 요청할 때의 시간이 정시 기준 10분을 안 넘었다면 이전 시간으로, 11분이 지났다면 현재 시각으로 요청하도록 구현함.
- 외부 Api 호출 비용/지연 줄이고, 응답 안정성 향상 위해 T1H을 짧은 TTL로 캐싱
- 사용자의 위/경도를 기상청이 요구하는 격자로 변환하는 유틸 `KmaGrid` 도입
- 응답 dto `WeatherResponse` 추가
- 컨트롤러, 서비스 코드 작성
- 유틸 테스트, 컨트롤러 테스트 코드 작성
- 외부 Api 관련 오류 시 `ExternalApiException` 사용 (503 매핑)

### 용어 정리
- KMA : 기상청(Korea Meteorological Administration) 오픈API
- 초단기실황 (getUltraSrtNcst) : "지금 시각"의 관측값 엔드포인트
- T1H : 기상청 초단기실황에서 기온을 의미
- nx, ny : 기상청이 요구하는 격자 좌표.(위/경도 아님)

###
<details>
  <summary>✅ Postman 요청 성공 사진</summary>
  
<img width="1428" height="985" alt="image" src="https://github.com/user-attachments/assets/011071a0-1103-4373-828b-7731abedd9a4" />
  
</details>